### PR TITLE
Add .github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug report
+about: Tell us about a problem you are experiencing
+
+---
+
+**What steps did you take and what happened:**
+[A clear and concise description on how to REPRODUCE the bug.]
+
+
+**What did you expect to happen:**
+
+
+**Anything else you would like to add:**
+[Miscellaneous information that will assist in solving the issue.]
+
+
+**Environment:**
+
+- Cluster-api version: 
+- Cluster-api-provider-kubevirt version: 
+- Kubernetes version: (use `kubectl version`): 
+- KubeVirt version:
+- OS (e.g. from `/etc/os-release`):
+
+/kind bug
+[One or more /area label. See https://github.com/kubernetes-sigs/cluster-api-provider-kubevirt/labels?q=area for the list of labels]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+i---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+<!-- NOTE: ⚠️ For larger proposals, we follow the CAEP process as outlined in https://sigs.k8s.io/cluster-api/CONTRIBUTING.md. -->
+
+**User Story**
+
+As a [developer/user/operator] I would like to [high level description] for [reasons]
+
+**Detailed Description**
+
+[A clear and concise description of what you want to happen.]
+
+**Anything else you would like to add:**
+
+[Miscellaneous information that will assist in solving the issue.]
+
+/kind feature

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+<!-- Thanks for sending a pull request! -->
+
+**What this PR does / why we need it**:
+
+**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
+
+**Special notes for your reviewer**:
+
+**Release notes**:
+<!--  Steps to write your release note:
+1. Use the release-note-* labels to set the release note state (if you have access)
+2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
+-->
+```release-note
+```


### PR DESCRIPTION
**What this PR does / why we need it**:
Add .github templates to set up the standard of PRs and ISSUEs

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
N/A
```