### PR TITLE
Add unit test for cluster_node_ssh_keys.go

### DIFF
--- a/pkg/loadbalancer/loadbalancer_test.go
+++ b/pkg/loadbalancer/loadbalancer_test.go
@@ -18,6 +18,7 @@ package loadbalancer_test
 
 import (
 	gocontext "context"
+	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -38,8 +39,8 @@ import (
 var (
 	clusterName         = "test-cluster"
 	kubevirtClusterName = "test-kubevirt-cluster"
-	kubevirtCluster     = newKubevirtCluster(clusterName, kubevirtClusterName)
-	cluster             = newCluster(clusterName, kubevirtCluster)
+	kubevirtCluster     = testing.NewKubevirtCluster(clusterName, kubevirtClusterName)
+	cluster             = testing.NewCluster(clusterName, kubevirtCluster)
 	loadBalancerService = newLoadBalancerService(kubevirtCluster)
 
 	clusterContext = &context.ClusterContext{
@@ -132,40 +133,6 @@ func setupScheme() *runtime.Scheme {
 		panic(err)
 	}
 	return s
-}
-
-func newCluster(clusterName string, kubevirtCluster *infrav1.KubevirtCluster) *clusterv1.Cluster {
-	cluster := &clusterv1.Cluster{
-		TypeMeta: metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: clusterName,
-		},
-	}
-	if kubevirtCluster != nil {
-		cluster.Spec.InfrastructureRef = &corev1.ObjectReference{
-			Name:       kubevirtCluster.Name,
-			Namespace:  kubevirtCluster.Namespace,
-			Kind:       kubevirtCluster.Kind,
-			APIVersion: kubevirtCluster.GroupVersionKind().GroupVersion().String(),
-		}
-	}
-	return cluster
-}
-
-func newKubevirtCluster(clusterName, kubevirtName string) *infrav1.KubevirtCluster {
-	return &infrav1.KubevirtCluster{
-		TypeMeta: metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: kubevirtName,
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					APIVersion: clusterv1.GroupVersion.String(),
-					Kind:       "Cluster",
-					Name:       clusterName,
-				},
-			},
-		},
-	}
 }
 
 func newLoadBalancerService(kubevirtCluster *infrav1.KubevirtCluster) *corev1.Service {

--- a/pkg/ssh/cluster_node_ssh_keys_test.go
+++ b/pkg/ssh/cluster_node_ssh_keys_test.go
@@ -1,0 +1,130 @@
+package ssh_test
+
+import (
+	gocontext "context"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	infrav1 "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha4"
+	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
+	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/ssh"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	kubevirtv1 "kubevirt.io/client-go/api/v1"
+	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/testing"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+var (
+	clusterName         = "test-cluster"
+	kubevirtClusterName = "test-kubevirt-cluster"
+	kubevirtCluster     = testing.NewKubevirtCluster(clusterName, kubevirtClusterName)
+	cluster             = testing.NewCluster(clusterName, kubevirtCluster)
+
+	clusterContext = &context.ClusterContext{
+		Logger:          ctrl.LoggerFrom(gocontext.TODO()).WithName("test"),
+		Context:         gocontext.TODO(),
+		Cluster:         cluster,
+		KubevirtCluster: kubevirtCluster,
+	}
+	clusterNodeSshKeys	ssh.ClusterNodeSshKeys
+)
+var _ = Describe("ClusterNodeSshKeys", func() {
+	var _ = Describe("test without ssh keys set", func() {
+		var (
+			fakeClient client.Client
+		)
+		Context("Generate new keys", func() {
+			BeforeEach(func() {
+				objects := []client.Object{
+					cluster,
+					kubevirtCluster,
+				}
+				fakeClient = fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
+				clusterNodeSshKeys = ssh.ClusterNodeSshKeys{
+					Client: fakeClient,
+					ClusterContext: clusterContext,
+				}
+			})
+			It("test generate new keys", func() {
+				err := clusterNodeSshKeys.GenerateNewKeys()
+				Expect(err).NotTo(HaveOccurred())
+			})
+			It("test persist keys", func() {
+				resp, errors := clusterNodeSshKeys.PersistKeysToSecret()
+				Expect(resp).To(BeNil())
+				Expect(errors).To(HaveOccurred())
+			})
+			It("test get keys", func() {
+				err, _ :=clusterNodeSshKeys.GetKeysDataSecret()
+				Expect(err).To(BeNil())
+			})
+			It("test is persisted false", func() {
+				result := clusterNodeSshKeys.IsPersistedToSecret()
+				Expect(result).To(BeFalse())
+			})
+			It("test fetch persisted keys from secret", func() {
+				err := clusterNodeSshKeys.FetchPersistedKeysFromSecret()
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+	var _ = Describe("test with ssh keys set", func() {
+		var (
+			fakeClient client.Client
+		)
+		Context("when SSHKey is set", func() {
+			BeforeEach(func() {
+				objects := []client.Object{
+					cluster,
+					kubevirtCluster,
+				}
+				fakeClient = fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
+				clusterNodeSshKeys = ssh.ClusterNodeSshKeys{
+					Client: fakeClient,
+					ClusterContext: clusterContext,
+				}
+			})
+			It("test persist keys", func() {
+				err := clusterNodeSshKeys.GenerateNewKeys()
+				Expect(err).NotTo(HaveOccurred())
+				sshKeysDataSecret, err := clusterNodeSshKeys.PersistKeysToSecret()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(sshKeysDataSecret.Name).To(Equal("test-kubevirt-cluster-ssh-keys"))
+				clusterContext.KubevirtCluster.Spec.SshKeys = infrav1.SSHKeys{
+					ConfigRef: &corev1.ObjectReference{
+						APIVersion: sshKeysDataSecret.APIVersion,
+						Kind:       sshKeysDataSecret.Kind,
+						Name:       sshKeysDataSecret.Name,
+						Namespace:  sshKeysDataSecret.Namespace,
+						UID:        sshKeysDataSecret.UID,
+					},
+					DataSecretName: &sshKeysDataSecret.Name,
+				}
+				secret, _ :=clusterNodeSshKeys.GetKeysDataSecret()
+				Expect(secret).NotTo(BeNil())
+				result := clusterNodeSshKeys.IsPersistedToSecret()
+				Expect(result).To(BeTrue())
+				_ = clusterNodeSshKeys.FetchPersistedKeysFromSecret()
+			})
+		})
+	})
+})
+func setupScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	if err := clusterv1.AddToScheme(s); err != nil {
+		panic(err)
+	}
+	if err := infrav1.AddToScheme(s); err != nil {
+		panic(err)
+	}
+	if err := kubevirtv1.AddToScheme(s); err != nil {
+		panic(err)
+	}
+	if err := corev1.AddToScheme(s); err != nil {
+		panic(err)
+	}
+	return s
+}

--- a/pkg/ssh/ssh_suite_test.go
+++ b/pkg/ssh/ssh_suite_test.go
@@ -1,0 +1,13 @@
+package ssh_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSsh(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Ssh Suite")
+}


### PR DESCRIPTION
What this PR does / why we need it:
The initial code migration for cluster-api-provider-kubevirt by Apple Inc.

Unit tests for cluster_node_ssh_keyss.go

Which issue this PR fixes (optional, in fixes #(, fixes #<issue_number>, ...) format, will close that issue when PR gets merged):
N/A

Special notes for your reviewer:
N/A

Release notes:

N/A