### PR TITLE
Make ssh bootstrap detection optional

### DIFF
--- a/api/v1alpha4/kubevirtmachine_types.go
+++ b/api/v1alpha4/kubevirtmachine_types.go
@@ -35,11 +35,6 @@ type KubevirtMachineSpec struct {
 	// ProviderID TBD what to use for Kubevirt
 	// +optional
 	ProviderID *string `json:"providerID,omitempty"`
-
-	// Bootstrapped is true when the kubeadm bootstrapping has been run
-	// against this machine
-	// +optional
-	Bootstrapped bool `json:"bootstrapped,omitempty"`
 }
 
 // KubevirtMachineStatus defines the observed state of KubevirtMachine.

--- a/api/v1alpha4/kubevirtmachinetemplate_webhook_test.go
+++ b/api/v1alpha4/kubevirtmachinetemplate_webhook_test.go
@@ -18,6 +18,7 @@ package v1alpha4
 
 import (
 	"errors"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -38,18 +39,14 @@ var _ = Describe("Template Validation", func() {
 				oldTemplate: &KubevirtMachineTemplate{
 					Spec: KubevirtMachineTemplateSpec{
 						Template: KubevirtMachineTemplateResource{
-							Spec: KubevirtMachineSpec{
-								Bootstrapped: true,
-							},
+							Spec: KubevirtMachineSpec{},
 						},
 					},
 				},
 				newTemplate: &KubevirtMachineTemplate{
 					Spec: KubevirtMachineTemplateSpec{
 						Template: KubevirtMachineTemplateResource{
-							Spec: KubevirtMachineSpec{
-								Bootstrapped: true,
-							},
+							Spec: KubevirtMachineSpec{},
 						},
 					},
 				},
@@ -64,13 +61,14 @@ var _ = Describe("Template Validation", func() {
 	})
 	Context("Template comparison with errors", func() {
 		BeforeEach(func() {
+			providerID := "test"
 			tests = test{
 				name: "return no error if no modification",
 				oldTemplate: &KubevirtMachineTemplate{
 					Spec: KubevirtMachineTemplateSpec{
 						Template: KubevirtMachineTemplateResource{
 							Spec: KubevirtMachineSpec{
-								Bootstrapped: true,
+								ProviderID: nil,
 							},
 						},
 					},
@@ -79,7 +77,7 @@ var _ = Describe("Template Validation", func() {
 					Spec: KubevirtMachineTemplateSpec{
 						Template: KubevirtMachineTemplateResource{
 							Spec: KubevirtMachineSpec{
-								Bootstrapped: false,
+								ProviderID: &providerID,
 							},
 						},
 					},

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_kubevirtmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_kubevirtmachines.yaml
@@ -38,10 +38,6 @@ spec:
           spec:
             description: KubevirtMachineSpec defines the desired state of KubevirtMachine.
             properties:
-              bootstrapped:
-                description: Bootstrapped is true when the kubeadm bootstrapping has
-                  been run against this machine
-                type: boolean
               providerID:
                 description: ProviderID TBD what to use for Kubevirt
                 type: string

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_kubevirtmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_kubevirtmachinetemplates.yaml
@@ -48,10 +48,6 @@ spec:
                     description: Spec is the specification of the desired behavior
                       of the machine.
                     properties:
-                      bootstrapped:
-                        description: Bootstrapped is true when the kubeadm bootstrapping
-                          has been run against this machine
-                        type: boolean
                       providerID:
                         description: ProviderID TBD what to use for Kubevirt
                         type: string

--- a/controllers/kubevirtmachine_controller.go
+++ b/controllers/kubevirtmachine_controller.go
@@ -225,7 +225,7 @@ func (r *KubevirtMachineReconciler) reconcileNormal(ctx *context.MachineContext)
 	}
 
 	// Wait for VM to boot
-	if !externalMachine.IsBooted() {
+	if !externalMachine.IsReady() {
 		ctx.Logger.Info("Waiting for underlying VM instance to boot...")
 		return ctrl.Result{RequeueAfter: 20 * time.Second}, nil
 	}

--- a/controllers/kubevirtmachine_controller_test.go
+++ b/controllers/kubevirtmachine_controller_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
@@ -105,6 +106,16 @@ var _ = Describe("KubevirtClusterToKubevirtMachines", func() {
 		}
 		Expect(machineNames).To(ConsistOf("test-machine", "another-test-machine"))
 	})
+})
+
+var _ = Describe("utility functions", func() {
+	table.DescribeTable("should detect userdata is cloud-config", func(userData []byte, expected bool) {
+		Expect(isCloudConfigUserData(userData)).To(Equal(expected))
+	},
+		table.Entry("should detect cloud-config", []byte("#something\n\n#something else\n#cloud-config\nthe end"), true),
+		table.Entry("should not detect cloud-config", []byte("#something\n\n#something else\n#not-cloud-config\nthe end"), false),
+		table.Entry("should not detect cloud-config", []byte("#something\n\n#something else\n   #cloud-config\nthe end"), false),
+	)
 })
 
 var _ = Describe("updateNodeProviderID", func() {

--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -7,3 +7,7 @@ set -e -o pipefail
 ./kubevirtci create-cluster
 ./kubevirtci kubectl wait --for=condition=ControlPlaneInitialized=true cluster/kvcluster --timeout=10m
 ./kubevirtci kubectl wait --for=condition=ControlPlaneReady=true cluster/kvcluster --timeout=10m
+
+CONTROL_PLANE_MACHINE=$(./kubevirtci kubectl get kubevirtmachine | grep kvcluster-control-plane | awk '{ print $1 }')
+./kubevirtci kubectl wait --for=condition=BootstrapExecSucceeded=true kubevirtmachine/${CONTROL_PLANE_MACHINE} --timeout=1m
+

--- a/pkg/kubevirt/machine.go
+++ b/pkg/kubevirt/machine.go
@@ -142,8 +142,8 @@ func (m *Machine) Address() string {
 	return ""
 }
 
-// IsBooted checks if the VM is booted.
-func (m *Machine) IsBooted() bool {
+// IsReady checks if the VM is ready
+func (m *Machine) IsReady() bool {
 	if !m.hasReadyCondition() {
 		return false
 	}
@@ -166,7 +166,7 @@ func (m *Machine) SupportsCheckingIsBootstrapped() bool {
 
 // IsBootstrapped checks if the VM is bootstrapped with Kubernetes.
 func (m *Machine) IsBootstrapped() bool {
-	if !m.IsBooted() {
+	if !m.IsReady() {
 		return false
 	}
 

--- a/pkg/kubevirt/machine_test.go
+++ b/pkg/kubevirt/machine_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Without KubeVirt VM running", func() {
 	AfterEach(func() {})
 
 	It("NewMachine should have client and machineContext set, but vmInstance equal nil", func() {
-		externalMachine, err := FakeNewMachine(machineContext, fakeClient, fakeVMCommandExecutor, []byte{})
+		externalMachine, err := defaultTestMachine(machineContext, fakeClient, fakeVMCommandExecutor, []byte{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(externalMachine.client).To(Equal(fakeClient))
 		Expect(externalMachine.machineContext).To(Equal(machineContext))
@@ -92,37 +92,37 @@ var _ = Describe("Without KubeVirt VM running", func() {
 	})
 
 	It("Exists should return false", func() {
-		externalMachine, err := FakeNewMachine(machineContext, fakeClient, fakeVMCommandExecutor, []byte{})
+		externalMachine, err := defaultTestMachine(machineContext, fakeClient, fakeVMCommandExecutor, []byte{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(externalMachine.Exists()).To(BeFalse())
 	})
 
 	It("Address should return ''", func() {
-		externalMachine, err := FakeNewMachine(machineContext, fakeClient, fakeVMCommandExecutor, []byte{})
+		externalMachine, err := defaultTestMachine(machineContext, fakeClient, fakeVMCommandExecutor, []byte{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(externalMachine.Address()).To(Equal(""))
 	})
 
-	It("IsBooted should return false", func() {
-		externalMachine, err := FakeNewMachine(machineContext, fakeClient, fakeVMCommandExecutor, []byte{})
+	It("IsReady should return false", func() {
+		externalMachine, err := defaultTestMachine(machineContext, fakeClient, fakeVMCommandExecutor, []byte{})
 		Expect(err).NotTo(HaveOccurred())
-		Expect(externalMachine.IsBooted()).To(BeFalse())
+		Expect(externalMachine.IsReady()).To(BeFalse())
 	})
 
 	It("IsBootstrapped should return false", func() {
-		externalMachine, err := FakeNewMachine(machineContext, fakeClient, fakeVMCommandExecutor, []byte{})
+		externalMachine, err := defaultTestMachine(machineContext, fakeClient, fakeVMCommandExecutor, []byte{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(externalMachine.IsBootstrapped()).To(BeFalse())
 	})
 
 	It("SupportsCheckingIsBootstrapped should return false", func() {
-		externalMachine, err := FakeNewMachine(machineContext, fakeClient, fakeVMCommandExecutor, []byte{})
+		externalMachine, err := defaultTestMachine(machineContext, fakeClient, fakeVMCommandExecutor, []byte{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(externalMachine.SupportsCheckingIsBootstrapped()).To(BeFalse())
 	})
 
 	It("GenerateProviderID should fail", func() {
-		externalMachine, err := FakeNewMachine(machineContext, fakeClient, fakeVMCommandExecutor, []byte{})
+		externalMachine, err := defaultTestMachine(machineContext, fakeClient, fakeVMCommandExecutor, []byte{})
 		Expect(err).NotTo(HaveOccurred())
 		providerId, err := externalMachine.GenerateProviderID()
 		Expect(err).To(HaveOccurred())
@@ -154,7 +154,7 @@ var _ = Describe("With KubeVirt VM running", func() {
 	AfterEach(func() {})
 
 	It("NewMachine should have all client, machineContext and vmInstance NOT nil", func() {
-		externalMachine, err := FakeNewMachine(machineContext, fakeClient, fakeVMCommandExecutor, []byte(sshKey))
+		externalMachine, err := defaultTestMachine(machineContext, fakeClient, fakeVMCommandExecutor, []byte(sshKey))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(externalMachine.client).ToNot(BeNil())
 		Expect(externalMachine.machineContext).To(Equal(machineContext))
@@ -162,31 +162,31 @@ var _ = Describe("With KubeVirt VM running", func() {
 	})
 
 	It("Exists should return true", func() {
-		externalMachine, err := FakeNewMachine(machineContext, fakeClient, fakeVMCommandExecutor, []byte(sshKey))
+		externalMachine, err := defaultTestMachine(machineContext, fakeClient, fakeVMCommandExecutor, []byte(sshKey))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(externalMachine.Exists()).To(BeTrue())
 	})
 
 	It("Address should return non-empty IP", func() {
-		externalMachine, err := FakeNewMachine(machineContext, fakeClient, fakeVMCommandExecutor, []byte(sshKey))
+		externalMachine, err := defaultTestMachine(machineContext, fakeClient, fakeVMCommandExecutor, []byte(sshKey))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(externalMachine.Address()).To(Equal(virtualMachineInstance.Status.Interfaces[0].IP))
 	})
 
-	It("IsBooted should return true", func() {
-		externalMachine, err := FakeNewMachine(machineContext, fakeClient, fakeVMCommandExecutor, []byte(sshKey))
+	It("IsReady should return true", func() {
+		externalMachine, err := defaultTestMachine(machineContext, fakeClient, fakeVMCommandExecutor, []byte(sshKey))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(externalMachine.IsBooted()).To(BeTrue())
+		Expect(externalMachine.IsReady()).To(BeTrue())
 	})
 
 	It("IsBootstrapped should return true", func() {
-		externalMachine, err := FakeNewMachine(machineContext, fakeClient, fakeVMCommandExecutor, []byte(sshKey))
+		externalMachine, err := defaultTestMachine(machineContext, fakeClient, fakeVMCommandExecutor, []byte(sshKey))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(externalMachine.IsBootstrapped()).To(BeTrue())
 	})
 
 	It("SupportsCheckingIsBootstrapped should return true", func() {
-		externalMachine, err := FakeNewMachine(machineContext, fakeClient, fakeVMCommandExecutor, []byte(sshKey))
+		externalMachine, err := defaultTestMachine(machineContext, fakeClient, fakeVMCommandExecutor, []byte(sshKey))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(externalMachine.SupportsCheckingIsBootstrapped()).To(BeTrue())
 	})
@@ -194,7 +194,7 @@ var _ = Describe("With KubeVirt VM running", func() {
 	It("GenerateProviderID should succeed", func() {
 		expectedProviderId := fmt.Sprintf("kubevirt://%s", kubevirtMachineName)
 
-		externalMachine, err := FakeNewMachine(machineContext, fakeClient, fakeVMCommandExecutor, []byte(sshKey))
+		externalMachine, err := defaultTestMachine(machineContext, fakeClient, fakeVMCommandExecutor, []byte(sshKey))
 		Expect(err).NotTo(HaveOccurred())
 		providerId, err := externalMachine.GenerateProviderID()
 		Expect(providerId).To(Equal(expectedProviderId))
@@ -238,7 +238,7 @@ func (e FakeVMCommandExecutor) ExecuteCommand(command string) (string, error) {
 	}
 }
 
-func FakeNewMachine(ctx *context.MachineContext, client client.Client, vmExecutor FakeVMCommandExecutor, sshPubKey []byte) (*Machine, error) {
+func defaultTestMachine(ctx *context.MachineContext, client client.Client, vmExecutor FakeVMCommandExecutor, sshPubKey []byte) (*Machine, error) {
 
 	machine, err := NewMachine(ctx, client, &ssh.ClusterNodeSshKeys{PublicKey: sshPubKey})
 

--- a/pkg/ssh/ssh_command_executor.go
+++ b/pkg/ssh/ssh_command_executor.go
@@ -25,14 +25,26 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-type VMCommandExecutor struct {
+type VMCommandExecutor interface {
+	ExecuteCommand(string) (string, error)
+}
+
+type vmCommandExecutor struct {
 	IPAddress  string
 	PublicKey  []byte
 	PrivateKey []byte
 }
 
+func NewVMCommandExecutor(address string, keys *ClusterNodeSshKeys) VMCommandExecutor {
+	return vmCommandExecutor{
+		IPAddress:  address,
+		PublicKey:  keys.PublicKey,
+		PrivateKey: keys.PrivateKey,
+	}
+}
+
 // ExecuteCommand runs command inside a VM, via SSH, and returns the command output.
-func (e VMCommandExecutor) ExecuteCommand(command string) (string, error) {
+func (e vmCommandExecutor) ExecuteCommand(command string) (string, error) {
 	// create signer
 	signer, err := signerFromPem(e.PrivateKey, []byte(""))
 

--- a/pkg/testing/common.go
+++ b/pkg/testing/common.go
@@ -99,3 +99,11 @@ func NewVirtualMachineInstance(kubevirtMachine *infrav1.KubevirtMachine) *kubevi
 		},
 	}
 }
+
+func NewBootstrapDataSecret(userData []byte) *corev1.Secret {
+
+	s := &corev1.Secret{}
+	s.Data = make(map[string][]byte)
+	s.Data["userdata"] = userData
+	return s
+}


### PR DESCRIPTION
Fixes: #26 

This PR makes the following changes.

* Only injects ssh keys when user-data is of type cloud-init, otherwise the userdata is taken directly as is with no modification.
* Determines if a VM is booted by checking the ready condition on the VMI rather than performing ssh execution for hostname.
* Optionally determines if a VM is bootstrapped only if the VM has ssh keys injected via cloud-init userdata, otherwise bootstrap detection of the sentinel file is ignored.
* Removes the kubevirtMachine.Spec.Bootstrapped boolean in favor of using conditions on the Status struct.

The overall result here is that previous behavior using the Kubeadm bootstrap provider is largely exactly the same. The only difference is that the IsBooted() check now only checks the ready condition on the VMI rather than executing ssh to get the host name. The IsBootstraped() function will still perform the ssh execution to verify the sentinel file exists though.

For non Kubeadm bootstrap providers (or any bootstrap provider that doesn't format the cloud-init userdata in cloud-config format) the only difference is that the sentinel file won't be checked.

Eventually we need to discuss alternatives to the ssh access for checking the sentinel file exists, but for now this preserves previous behavior and allows CAPK to work with other bootstrap sources.

```release-note
Makes ssh bootstrap detection optional
```
