### PR TITLE
Add unit- and functional test runners based on github actions

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,22 @@
+on: [pull_request]
+name: e2e
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          repository: kubevirt/project-infra
+          path: project-infra
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: kubeconfig
+        run: 'echo -e "$KUBECONFIG" > $GITHUB_WORKSPACE/project-infra/.kubeconfig'
+        shell: bash
+        env:
+          KUBECONFIG: ${{secrets.KUBECONFIG}}
+      - name: Test
+        run: |
+          $GITHUB_WORKSPACE/project-infra/hack/mkpj.sh --job pull-kubernetes-sigs-cluster-api-provider-kubevirt-e2e --pull-number ${{github.event.number}} --kubeconfig $GITHUB_WORKSPACE/project-infra/.kubeconfig --trigger-job

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,20 @@
+on: [push, pull_request]
+name: Test
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [1.16.x, 1.17.x]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Test
+      run: make test
+    - name: Build
+      run: make manager


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Add github actions for:

 * running unit tests
 * building the capik manager
 * triggering an e2e jobs in kubevirt-prow and wait for its completion

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

Two points to consider:

 * A KUBECONFIG secret needs to be added to github actions to make the e2e job work.
 * The job right now also succeeds if the remote jobs fails, it just indicates the end of the remote job, not if it succeeded or failed.

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
