### PR TITLE
Dockerized manager build script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ test-junit: $(GOTESTSUM) ## Run tests with verbose setting and generate a junit 
 
 .PHONY: manager
 manager: ## Build manager binary
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $(BIN_DIR)/manager
+	./hack/docker-builder.sh
 
 $(CONTROLLER_GEN): $(TOOLS_DIR)/go.mod # Build controller-gen from tools folder.
 	cd $(TOOLS_DIR); go build -tags=tools -o $(BIN_DIR)/controller-gen sigs.k8s.io/controller-tools/cmd/controller-gen

--- a/hack/docker-builder.sh
+++ b/hack/docker-builder.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -e
+
+DOCKER_BUILD_IMAGE=${DOCKER_BUILD_IMAGE:-"golang:1.17"}
+DOCKER_BUILD_VOLUME=${DOCKER_BUILD_VOLUME:-"capk_build_cache"}
+DOCKER_BUILD_CACHE=${DOCKER_BUILD_CACHE:-"/root/.cache/go-build"}
+
+BIN_DIR=${BIN_DIR:-"bin"}
+
+CGO_ENABLED=0
+GOOS=linux
+GOARCH=amd64
+
+TMP_BUILD_SCRIPT=".docker-build-script.sh"
+
+mkdir -p $BIN_DIR
+
+
+create_tmp_build_script() {
+
+	_uid=$(id -u)
+	_gid=$(id -g)
+
+	cat << EOF > ${TMP_BUILD_SCRIPT}
+#!/bin/bash
+set -e
+go build -o "${BIN_DIR}/manager"
+chown "${_uid}:${_gid}" "${BIN_DIR}/manager"
+EOF
+chmod 755 .docker-build-script.sh
+
+}
+
+if [ "${CAPK_DOCKERIZED_BUILD}" == "true" ]; then
+	echo "Using dockerized builder"
+
+	create_tmp_build_script
+	docker volume create "$DOCKER_BUILD_VOLUME"
+	docker run --rm \
+		--mount type=bind,source="${PWD}",target="/src" \
+		--mount source="${DOCKER_BUILD_VOLUME}",target="${DOCKER_BUILD_CACHE}" \
+		-e GOMODCACHE="${DOCKER_BUILD_CACHE}" \
+		-e CGO_ENABLED=${CGO_ENABLED} \
+		-e GOOS=${GOOS} \
+		-e GOARCH=${GOARCH} \
+		--workdir "/src" \
+		$DOCKER_BUILD_IMAGE \
+		"./$TMP_BUILD_SCRIPT"
+
+	rm ${TMP_BUILD_SCRIPT}
+else 
+	go build -o ${BIN_DIR}/manager
+fi


### PR DESCRIPTION
This introduces an optional path for building the capk manager binary using a standardized docker container. This allows us to optionally decouple the golang build version from whatever is running locally on our dev machines.

running the following will use a golang base container to build the manager binary and dump it into the src tree's `bin/manager` directory.

```
CAPK_DOCKERIZED_BUILD=true make manager
```

The existing `make manager` without usage of the CAPK_DOCKERIZED_BUILD env var remains unchanged, and will use the local go environment.

```release-note
NONE
```
