### PR TITLE
Fixes "failed to create VM instance" error

### DIFF
--- a/pkg/kubevirt/machine.go
+++ b/pkg/kubevirt/machine.go
@@ -105,14 +105,6 @@ func (m *Machine) Create() error {
 		return err
 	}
 
-	namespacedName := types.NamespacedName{Namespace: m.machineContext.KubevirtMachine.Namespace, Name: m.machineContext.KubevirtMachine.Name}
-	vmi := &kubevirtv1.VirtualMachineInstance{}
-	if err := m.client.Get(m.machineContext.Context, namespacedName, vmi); err != nil {
-		if apierrors.IsNotFound(err) {
-			return errors.New("failed to create VM instance")
-		}
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
This PR introduces two changes.

* Adds unit tests to exercise reconcileNormal() behavior
* fixes race condition in kubevirt machine controller that causes reconcile error immediately after VM creation

I noticed quite a few `failed to create VM instance` errors in the logs and found a race condition in our VM creation logic. If we attempt to get a VM's VMI immediately after VM creation, there's a very high chance that get will fail. This is because the VM controller has not had enough time to react to the created VM and create the corresponding VMI object.

We don't actually need to check to see if the VMI has been created immediately after the VM is created. Now that the machine controller is checking the `IsReady()` function, we'll naturally wait (re-enqueue) the VMI to get recreated before proceeding with the rest of the controllers logic.

This pr also introduces some unit tests to verify we re-enqueue after VM creation.

```release-note
NONE
```
