### PR TITLE
Add Dockerfile to build manager binary and emit production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,61 @@
-FROM gcr.io/distroless/static
+# syntax=docker/dockerfile:1.1-experimental
 
-COPY bin/manager /usr/bin/
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-ENTRYPOINT /usr/bin/manager
+# Build the manager binary
+# Run this with docker build --build-arg builder_image=<golang:x.y.z>
+ARG builder_image=golang:1.16.2
+FROM ${builder_image} as builder
+WORKDIR /workspace
+
+# Run this with docker build --build-arg goproxy=$(go env GOPROXY) to override the goproxy
+ARG goproxy=https://proxy.golang.org
+ENV GOPROXY=$goproxy
+
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+# Cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+# Copy the sources
+COPY ./ ./
+
+# Cache the go build into the the Go’s compiler cache folder so we take benefits of compiler caching across docker build calls
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    go build .
+
+# Build
+ARG ARCH=amd64
+ARG ldflags
+
+# Do not force rebuild of up-to-date packages (do not use -a) and use the compiler cache folder
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} \
+    go build -a -ldflags "${ldflags} -extldflags '-static'" \
+    -o manager .
+
+# Production image
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY --from=builder /workspace/manager .
+# Use uid of nonroot user (65532) because kubernetes expects numeric user when applying pod security policies
+USER 65532
+ENTRYPOINT ["/manager"]

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -16,11 +16,12 @@ spec:
         control-plane: controller-manager
     spec:
       containers:
-      - args:
+      - command:
+        - /manager
+        args:
         - "--leader-elect"
         - "--metrics-bind-addr=127.0.0.1:8080"
         - "--feature-gates=MachinePool=false"
-        command: ["/usr/bin/manager"]
         image: controller:latest
         name: manager
         env:


### PR DESCRIPTION
**What this PR does / why we need it**:
Update Dockerfile to build manager binary and emit production image. The Dockerfile is inspired from CAPI.

**Which issue this PR fixes**: fixes #45 
