### PR TITLE
Make secrets for third-party PRs available

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,8 +1,11 @@
-on: [pull_request]
+on:
+  pull_request_target:
+    types: [labeled]
 name: e2e
 jobs:
-  docker:
+  integration:
     runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
**What this PR does / why we need it**:

If a PR gets labeled with `ok-to-test` the integration test job is
triggered and this github action has access to secrets.

The github action does for security resaons not allow secrets on all
PRs, so we add this extra step.

Still, the action itself, while using a secret, does not have any
interaction points with users. The PR content is actually not even
checked out.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

Also see https://securitylab.github.com/research/github-actions-preventing-pwn-requests/ for more details and being able to judge for yourself if you consider this safe.

**Release notes**:

```release-note
NONE
```
