### PR TITLE
Make integration tests independent of go version changes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,7 +1,7 @@
 on: [push, pull_request]
-name: Test
+name: build
 jobs:
-  test:
+  unit_test:
     strategy:
       matrix:
         go-version: [1.16.x, 1.17.x]

--- a/kubevirtci
+++ b/kubevirtci
@@ -65,7 +65,6 @@ function kubevirtci::down() {
 
 function kubevirtci::build() {
 	export REGISTRY="localhost:$(cluster-up/cluster-up/cli.sh ports registry)"
-	make manager
 	make docker-build
 	make docker-push
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

With the new Dockerfile in place with #46  which builds the manager binary, the
binary does not have to be built upfront with the external golang
version. Instead the internal one can be used which makes for instance
integration jobs independent of the go versions installed there.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
