### PR TITLE
Limit github action to run only on the kubernetes-sigs/cluster-api-provider-kubevirt repository

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -5,7 +5,7 @@ name: e2e
 jobs:
   integration:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    if: (github.repository == 'kubernetes-sigs/cluster-api-provider-kubevirt') && contains(github.event.pull_request.labels.*.name, 'ok-to-test')
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,7 @@ on: [push, pull_request]
 name: build
 jobs:
   unit_test:
+    if: (github.repository == 'kubernetes-sigs/cluster-api-provider-kubevirt')
     strategy:
       matrix:
         go-version: [1.16.x, 1.17.x]


### PR DESCRIPTION
Add a condition to the github action, to prevent them to run on another repositories, like forks.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
We don't want the github action to run on forks of this repository. This PR prevents that.

**Special notes for your reviewer**:

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
