### PR TITLE
Add the new --fail-with-job flag to let mkpj fail when the prowjob fails

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -20,4 +20,4 @@ jobs:
           KUBECONFIG: ${{secrets.KUBECONFIG}}
       - name: Test
         run: |
-          $GITHUB_WORKSPACE/project-infra/hack/mkpj.sh --job pull-kubernetes-sigs-cluster-api-provider-kubevirt-e2e --pull-number ${{github.event.number}} --kubeconfig $GITHUB_WORKSPACE/project-infra/.kubeconfig --trigger-job
+          $GITHUB_WORKSPACE/project-infra/hack/mkpj.sh --job pull-kubernetes-sigs-cluster-api-provider-kubevirt-e2e --pull-number ${{github.event.number}} --kubeconfig $GITHUB_WORKSPACE/project-infra/.kubeconfig --trigger-job --fail-with-job


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/kubernetes/test-infra/pull/24686 landed a while ago, the new mkpj flag can be used now.
The github action will now also fail when the prowjob failed and not just indicate when the prowjob is done.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

The change will only be effective after this PR with the change is merged.

**Release notes**:

```release-note
NONE
```
