### PR TITLE
make 0.1.x version of kubevirt provider compatible with 1.0.x version of cluster-api

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -8,4 +8,4 @@ kind: Metadata
 releaseSeries:
   - major: 0
     minor: 1
-    contract: v1alpha1
+    contract: v1beta1


### PR DESCRIPTION
**What this PR does / why we need it**:
`metadata.yaml` is intended to indicate compatibility of versions between cluster-api and providers

currently, kubevirt provider metadata declares compatibility with cluster-api `v0.1.x` while it's actually compatible with cluster-api `v1.0.x`

one manifestation of this is an error below when using current version of kubevirt provider with clusterctl `v1.0.x`:
```
Fetching providers
Error: current version of clusterctl is only compatible with v1beta1 providers, detected v1alpha1 for provider infrastructure-kubevirt
```

after this code change, such error no longer shows, and we can successfully intialize capi management plane with capi `v1.0.x` and capk `v0.1.x`
```
Fetching providers
Installing cert-manager Version="v1.5.3"
Waiting for cert-manager to be available...
Installing Provider="cluster-api" Version="v1.0.99" TargetNamespace="capi-system"
Installing Provider="bootstrap-kubeadm" Version="v1.0.99" TargetNamespace="capi-kubeadm-bootstrap-system"
Installing Provider="control-plane-kubeadm" Version="v1.0.99" TargetNamespace="capi-kubeadm-control-plane-system"
Installing Provider="infrastructure-kubevirt" Version="v0.1.0" TargetNamespace="capk-system"

Your management cluster has been initialized successfully!
```

**Which issue this PR fixes**: fixes #62


**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```NONE
```
