### PR TITLE
fix API versions in external infra template

### DIFF
--- a/templates/cluster-template-ext-infra.yaml
+++ b/templates/cluster-template-ext-infra.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: cluster.x-k8s.io/v1alpha4
+apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   name: "${CLUSTER_NAME}"
@@ -10,17 +10,17 @@ spec:
       cidrBlocks:
         - 10.244.0.0/16
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
     kind: KubevirtCluster
     name: '${CLUSTER_NAME}'
     namespace: "${NAMESPACE}"
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
     kind: KubeadmControlPlane
     name: '${CLUSTER_NAME}-control-plane'
     namespace: "${NAMESPACE}"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: KubevirtCluster
 metadata:
   name: "${CLUSTER_NAME}"
@@ -32,7 +32,7 @@ spec:
     name: external-infra-kubeconfig
     namespace: capk-system
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: KubevirtMachineTemplate
 metadata:
   name: "${CLUSTER_NAME}-control-plane"
@@ -61,7 +61,7 @@ spec:
                   name: containervolume
 ---
 kind: KubeadmControlPlane
-apiVersion: controlplane.cluster.x-k8s.io/v1alpha4
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 metadata:
   name: "${CLUSTER_NAME}-control-plane"
   namespace: "${NAMESPACE}"
@@ -70,7 +70,7 @@ spec:
   machineTemplate:
     infrastructureRef:
       kind: KubevirtMachineTemplate
-      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
       name: "${CLUSTER_NAME}-control-plane"
       namespace: "${NAMESPACE}"
   kubeadmConfigSpec:
@@ -84,7 +84,7 @@ spec:
         criSocket: "{CRI_PATH}"
   version: "${KUBERNETES_VERSION}"
 ---
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: KubevirtMachineTemplate
 metadata:
   name: "${CLUSTER_NAME}-md-0"
@@ -112,7 +112,7 @@ spec:
                     image: "${NODE_VM_IMAGE_TEMPLATE}"
                   name: containervolume
 ---
-apiVersion: bootstrap.cluster.x-k8s.io/v1alpha4
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
   name: "${CLUSTER_NAME}-md-0"
@@ -124,7 +124,7 @@ spec:
         nodeRegistration:
           kubeletExtraArgs: {}
 ---
-apiVersion: cluster.x-k8s.io/v1alpha4
+apiVersion: cluster.x-k8s.io/v1beta1
 kind: MachineDeployment
 metadata:
   name: "${CLUSTER_NAME}-md-0"
@@ -142,10 +142,10 @@ spec:
         configRef:
           name: "${CLUSTER_NAME}-md-0"
           namespace: "${NAMESPACE}"
-          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha4
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
           kind: KubeadmConfigTemplate
       infrastructureRef:
         name: "${CLUSTER_NAME}-md-0"
         namespace: "${NAMESPACE}"
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha4
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
         kind: KubevirtMachineTemplate


### PR DESCRIPTION
**What this PR does / why we need it**:
- use v1beta1 versions for cluster-api resources
- use v1alpha1 versions for kubevirt provider resources

**Release notes**:
```NONE
```
