### PR TITLE
Run e2e test also on label events

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,4 +1,7 @@
-on: [pull_request_target, push]
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled]
+  push: {}
 name: e2e
 jobs:
   integration:


### PR DESCRIPTION
**What this PR does / why we need it**:

Ensure that we react to a label change on the PR to ensure that the e2e
tests get triggered if someone writes /ok-to-test some time after the PR
got created.

`labeled` is the new event. The other three events are the default values.

Right now, if the label gets added to PRs some time later, github will not reconsider if it has to run the integration test unless the code in the PR gets repushed.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release notes**:

```release-note
NONE
```
