### PR TITLE
Continually reconcile KubeVirtMachine objects

### DIFF
--- a/api/v1alpha1/kubevirtcluster_types.go
+++ b/api/v1alpha1/kubevirtcluster_types.go
@@ -28,6 +28,11 @@ const (
 	ClusterFinalizer = "kubevirtcluster.infrastructure.cluster.x-k8s.io"
 )
 
+const (
+	KubevirtMachineNameLabel      = "capk.cluster.x-k8s.io/kubevirt-machine-name"
+	KubevirtMachineNamespaceLabel = "capk.cluster.x-k8s.io/kubevirt-machine-namespace"
+)
+
 // KubevirtClusterSpec defines the desired state of KubevirtCluster.
 type KubevirtClusterSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster

--- a/controllers/kubevirtmachine_controller.go
+++ b/controllers/kubevirtmachine_controller.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	kubevirtv1 "kubevirt.io/api/core/v1"
 	infrav1 "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
 	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
 	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/infracluster"
@@ -158,22 +159,21 @@ func (r *KubevirtMachineReconciler) Reconcile(goctx gocontext.Context, req ctrl.
 	}
 
 	// Handle non-deleted machines
-	if !machineContext.KubevirtMachine.Status.Ready {
-		return r.reconcileNormal(machineContext)
-	} else {
+	res, err := r.reconcileNormal(machineContext)
+
+	if res.IsZero() &&
+		err == nil &&
+		!machineContext.KubevirtMachine.Status.Ready {
 		// Update the providerID on the Node
 		// The ProviderID on the Node and the providerID on  the KubevirtMachine are used to set the NodeRef
 		// This code is needed here as long as there is no Kubevirt cloud provider setting the providerID in the node
 		return r.updateNodeProviderID(machineContext)
 	}
+
+	return res, err
 }
 
 func (r *KubevirtMachineReconciler) reconcileNormal(ctx *context.MachineContext) (res ctrl.Result, retErr error) {
-	// If the machine is already provisioned, return
-	if ctx.KubevirtMachine.Status.Ready {
-		ctx.Logger.Info("KubevirtMachine.Status.Ready is set -- nothing to do!")
-		return ctrl.Result{}, nil
-	}
 
 	// Make sure bootstrap data is available and populated.
 	if ctx.Machine.Spec.Bootstrap.DataSecretName == nil {
@@ -231,22 +231,28 @@ func (r *KubevirtMachineReconciler) reconcileNormal(ctx *context.MachineContext)
 
 	// Provision the underlying VM if not existing
 	if !externalMachine.Exists() {
+		ctx.KubevirtMachine.Status.Ready = false
 		if err := externalMachine.Create(ctx.Context); err != nil {
 			return ctrl.Result{}, errors.Wrap(err, "failed to create VM instance")
 		}
-	}
-
-	// Wait for VM to boot
-	if !externalMachine.IsReady() {
-		ctx.Logger.Info("KubeVirt VM is not ready...")
+		ctx.Logger.Info("VM Created, waiting on vm to be provisioned.")
 		return ctrl.Result{RequeueAfter: 20 * time.Second}, nil
 	}
 
-	conditions.MarkTrue(ctx.KubevirtMachine, infrav1.VMProvisionedCondition)
+	if externalMachine.IsReady() {
+		// Mark VMProvisionedCondition to indicate that the VM has successfully started
+		conditions.MarkTrue(ctx.KubevirtMachine, infrav1.VMProvisionedCondition)
+	} else {
+		// Waiting for VM to boot
+		ctx.KubevirtMachine.Status.Ready = false
+		ctx.Logger.Info("KubeVirt VM is not fully provisioned and running...")
+		return ctrl.Result{RequeueAfter: 20 * time.Second}, nil
+	}
 
 	ipAddress := externalMachine.Address()
 	if ipAddress == "" {
 		ctx.Logger.Info(fmt.Sprintf("KubevirtMachine %s: Got empty ipAddress, requeue", ctx.KubevirtMachine.Name))
+		ctx.KubevirtMachine.Status.Ready = false
 		return ctrl.Result{RequeueAfter: 20 * time.Second}, nil
 	}
 
@@ -254,6 +260,7 @@ func (r *KubevirtMachineReconciler) reconcileNormal(ctx *context.MachineContext)
 		if !externalMachine.IsBootstrapped() {
 			ctx.Logger.Info("Waiting for underlying VM to bootstrap...")
 			conditions.MarkFalse(ctx.KubevirtMachine, infrav1.BootstrapExecSucceededCondition, infrav1.BootstrapFailedReason, clusterv1.ConditionSeverityWarning, "VM not bootstrapped yet")
+			ctx.KubevirtMachine.Status.Ready = false
 			return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 		}
 		// Update the condition BootstrapExecSucceededCondition
@@ -280,18 +287,23 @@ func (r *KubevirtMachineReconciler) reconcileNormal(ctx *context.MachineContext)
 		},
 	}
 
-	providerID, err := externalMachine.GenerateProviderID()
-	if err != nil {
-		ctx.Logger.Error(err, "Failed to patch node with provider id.")
-		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	if ctx.KubevirtMachine.Spec.ProviderID == nil || *ctx.KubevirtMachine.Spec.ProviderID == "" {
+		providerID, err := externalMachine.GenerateProviderID()
+		if err != nil {
+			ctx.Logger.Error(err, "Failed to patch node with provider id.")
+			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+		}
+
+		// Set ProviderID so the Cluster API Machine Controller can pull it.
+		ctx.KubevirtMachine.Spec.ProviderID = &providerID
 	}
 
-	// Set ProviderID so the Cluster API Machine Controller can pull it.
-	ctx.KubevirtMachine.Spec.ProviderID = &providerID
-
-	// KubevirtMachine is ready! Set the status and the condition.
-	ctx.KubevirtMachine.Status.Ready = true
-	conditions.MarkTrue(ctx.KubevirtMachine, infrav1.VMProvisionedCondition)
+	// Ready should reflect if the VMI is ready or not
+	if externalMachine.IsReady() {
+		ctx.KubevirtMachine.Status.Ready = true
+	} else {
+		ctx.KubevirtMachine.Status.Ready = false
+	}
 
 	return ctrl.Result{}, nil
 }
@@ -410,6 +422,14 @@ func (r *KubevirtMachineReconciler) SetupWithManager(goctx gocontext.Context, mg
 			&source.Kind{Type: &infrav1.KubevirtCluster{}},
 			handler.EnqueueRequestsFromMapFunc(r.KubevirtClusterToKubevirtMachines),
 		).
+		Watches(
+			&source.Kind{Type: &kubevirtv1.VirtualMachineInstance{}},
+			handler.EnqueueRequestsFromMapFunc(r.VMIToKubevirtMachines),
+		).
+		Watches(
+			&source.Kind{Type: &kubevirtv1.VirtualMachine{}},
+			handler.EnqueueRequestsFromMapFunc(r.VMToKubevirtMachines),
+		).
 		Build(r)
 	if err != nil {
 		return err
@@ -419,6 +439,50 @@ func (r *KubevirtMachineReconciler) SetupWithManager(goctx gocontext.Context, mg
 		handler.EnqueueRequestsFromMapFunc(clusterToKubevirtMachines),
 		predicates.ClusterUnpausedAndInfrastructureReady(ctrl.LoggerFrom(goctx)),
 	)
+}
+
+func (r *KubevirtMachineReconciler) VMIToKubevirtMachines(o client.Object) []ctrl.Request {
+	var result []ctrl.Request
+	vmi, ok := o.(*kubevirtv1.VirtualMachineInstance)
+	if !ok {
+		panic(fmt.Sprintf("Expected a VirtualMachineInstance but got a %T", o))
+	}
+
+	machineNamespace, exists := vmi.Labels[infrav1.KubevirtMachineNamespaceLabel]
+	if !exists {
+		return result
+	}
+	machineName, exists := vmi.Labels[infrav1.KubevirtMachineNameLabel]
+	if !exists {
+		return result
+	}
+
+	name := client.ObjectKey{Namespace: machineNamespace, Name: machineName}
+	result = append(result, ctrl.Request{NamespacedName: name})
+
+	return result
+}
+
+func (r *KubevirtMachineReconciler) VMToKubevirtMachines(o client.Object) []ctrl.Request {
+	var result []ctrl.Request
+	vm, ok := o.(*kubevirtv1.VirtualMachine)
+	if !ok {
+		panic(fmt.Sprintf("Expected a VirtualMachine but got a %T", o))
+	}
+
+	machineNamespace, exists := vm.Labels[infrav1.KubevirtMachineNamespaceLabel]
+	if !exists {
+		return result
+	}
+	machineName, exists := vm.Labels[infrav1.KubevirtMachineNameLabel]
+	if !exists {
+		return result
+	}
+
+	name := client.ObjectKey{Namespace: machineNamespace, Name: machineName}
+	result = append(result, ctrl.Request{NamespacedName: name})
+
+	return result
 }
 
 // KubevirtClusterToKubevirtMachines is a handler.ToRequestsFunc to be used to enqueue

--- a/controllers/kubevirtmachine_controller.go
+++ b/controllers/kubevirtmachine_controller.go
@@ -239,6 +239,7 @@ func (r *KubevirtMachineReconciler) reconcileNormal(ctx *context.MachineContext)
 		return ctrl.Result{RequeueAfter: 20 * time.Second}, nil
 	}
 
+	// Checks to see if a VM's active VMI is ready or not
 	if externalMachine.IsReady() {
 		// Mark VMProvisionedCondition to indicate that the VM has successfully started
 		conditions.MarkTrue(ctx.KubevirtMachine, infrav1.VMProvisionedCondition)

--- a/controllers/kubevirtmachine_controller_test.go
+++ b/controllers/kubevirtmachine_controller_test.go
@@ -349,6 +349,62 @@ var _ = Describe("reconcile a kubevirt machine", func() {
 		Expect(*machineContext.KubevirtMachine.Spec.ProviderID).To(Equal("kubevirt://" + kubevirtMachineName))
 	})
 
+	It("should detect when a previous Ready KubeVirtMachine is no longer ready due to vmi ready condition being false", func() {
+		vmi.Status.Conditions = []kubevirtv1.VirtualMachineInstanceCondition{
+			{
+				Type:   kubevirtv1.VirtualMachineInstanceReady,
+				Status: corev1.ConditionFalse,
+			},
+		}
+
+		kubevirtMachine.Status.Ready = true
+		objects := []client.Object{
+			cluster,
+			kubevirtCluster,
+			machine,
+			kubevirtMachine,
+			sshKeySecret,
+			bootstrapSecret,
+			bootstrapUserDataSecret,
+			vm,
+			vmi,
+		}
+
+		setupClient(objects)
+
+		clusterContext := &context.ClusterContext{Context: machineContext.Context, Cluster: machineContext.Cluster, KubevirtCluster: machineContext.KubevirtCluster, Logger: machineContext.Logger}
+		infraClusterMock.EXPECT().GenerateInfraClusterClient(clusterContext).Return(fakeClient, cluster.Namespace, nil)
+
+		Expect(machineContext.KubevirtMachine.Status.Ready).To(BeTrue())
+		out, err := kubevirtMachineReconciler.reconcileNormal(machineContext)
+		Expect(machineContext.KubevirtMachine.Status.Ready).To(BeFalse())
+		Expect(err).To(BeNil())
+		Expect(out).To(Equal(ctrl.Result{RequeueAfter: 20 * time.Second}))
+	})
+
+	It("should detect when a previous Ready KubeVirtMachine is no longer ready due to missing vmi object", func() {
+		kubevirtMachine.Status.Ready = true
+		objects := []client.Object{
+			cluster,
+			kubevirtCluster,
+			machine,
+			kubevirtMachine,
+			sshKeySecret,
+			bootstrapSecret,
+			bootstrapUserDataSecret,
+		}
+
+		setupClient(objects)
+
+		clusterContext := &context.ClusterContext{Context: machineContext.Context, Cluster: machineContext.Cluster, KubevirtCluster: machineContext.KubevirtCluster, Logger: machineContext.Logger}
+		infraClusterMock.EXPECT().GenerateInfraClusterClient(clusterContext).Return(fakeClient, cluster.Namespace, nil)
+
+		Expect(machineContext.KubevirtMachine.Status.Ready).To(BeTrue())
+		out, err := kubevirtMachineReconciler.reconcileNormal(machineContext)
+		Expect(machineContext.KubevirtMachine.Status.Ready).To(BeFalse())
+		Expect(err).To(BeNil())
+		Expect(out).To(Equal(ctrl.Result{RequeueAfter: 20 * time.Second}))
+	})
 })
 
 var _ = Describe("updateNodeProviderID", func() {

--- a/e2e-tests/create-cluster_test.go
+++ b/e2e-tests/create-cluster_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -15,6 +16,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
+	kubevirtv1 "kubevirt.io/api/core/v1"
 	infrav1 "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
 	tests "sigs.k8s.io/cluster-api-provider-kubevirt/e2e-tests"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -49,6 +51,7 @@ var _ = Describe("CreateCluster", func() {
 
 		clusterv1.AddToScheme(k8sclient.Scheme())
 		infrav1.AddToScheme(k8sclient.Scheme())
+		kubevirtv1.AddToScheme(k8sclient.Scheme())
 
 		namespace = "e2e-test-create-cluster-" + rand.String(6)
 
@@ -103,23 +106,55 @@ var _ = Describe("CreateCluster", func() {
 
 	})
 
-	It("creating a simple cluster", func() {
+	waitForBootstrappedMachines := func() {
+		Eventually(func() error {
+			machineList := &infrav1.KubevirtMachineList{}
+			err := k8sclient.List(context.Background(), machineList, client.InNamespace(namespace))
+			if err != nil {
+				return err
+			}
 
-		By("generating cluster manifests from example template")
-		cmd := exec.Command(tests.ClusterctlPath, "generate", "cluster", "kvcluster", "--target-namespace", namespace, "--kubernetes-version", "v1.21.0", "--control-plane-machine-count=1", "--worker-machine-count=1", "--from", "templates/cluster-template.yaml")
-		cmd.Env = append(os.Environ(),
-			"NODE_VM_IMAGE_TEMPLATE=quay.io/kubevirtci/fedora-kubeadm:35",
-			"IMAGE_REPO=k8s.gcr.io",
-			"CRI_PATH=/var/run/crio/crio.sock",
-		)
-		stdout, _ := tests.RunCmd(cmd)
-		err := os.WriteFile(manifestsFile, stdout, 0644)
-		Expect(err).To(BeNil())
+			for _, machine := range machineList.Items {
+				if !conditions.IsTrue(&machine, infrav1.BootstrapExecSucceededCondition) {
+					return fmt.Errorf("still waiting on a kubevirt machine with bootstrap succeeded condition")
+				}
+			}
+			return nil
+		}, 5*time.Minute, 5*time.Second).Should(BeNil(), "kubevirt machines should have bootstrap succeeded condition")
 
-		By("posting cluster manifests example template")
-		cmd = exec.Command(tests.KubectlPath, "apply", "-f", manifestsFile)
-		tests.RunCmd(cmd)
+	}
 
+	waitForMachineReadiness := func(numExpectedReady int, numExpectedNotReady int) {
+		Eventually(func() error {
+
+			readyCount := 0
+			notReadyCount := 0
+
+			machineList := &infrav1.KubevirtMachineList{}
+			err := k8sclient.List(context.Background(), machineList, client.InNamespace(namespace))
+			if err != nil {
+				return err
+			}
+
+			for _, machine := range machineList.Items {
+				if machine.Status.Ready {
+					readyCount++
+				} else {
+					notReadyCount++
+				}
+			}
+
+			if readyCount != numExpectedReady {
+				return fmt.Errorf("Expected %d ready, but got %d", numExpectedReady, readyCount)
+			} else if notReadyCount != numExpectedNotReady {
+				return fmt.Errorf("Expected %d not ready, but got %d", numExpectedNotReady, notReadyCount)
+			}
+
+			return nil
+		}, 5*time.Minute, 5*time.Second).Should(BeNil(), "waiting for expected readiness.")
+	}
+
+	waitForControlPlane := func() {
 		By("Waiting on cluster's control plane to initialize")
 		Eventually(func() error {
 			cluster := &clusterv1.Cluster{}
@@ -151,21 +186,82 @@ var _ = Describe("CreateCluster", func() {
 
 			return nil
 		}, 10*time.Minute, 5*time.Second).Should(BeNil(), "cluster should have control plane initialized")
+	}
+
+	It("creating a simple cluster with ephemeral VMs", func() {
+		By("generating cluster manifests from example template")
+		cmd := exec.Command(tests.ClusterctlPath, "generate", "cluster", "kvcluster", "--target-namespace", namespace, "--kubernetes-version", "v1.21.0", "--control-plane-machine-count=1", "--worker-machine-count=1", "--from", "templates/cluster-template.yaml")
+		cmd.Env = append(os.Environ(),
+			"NODE_VM_IMAGE_TEMPLATE=quay.io/kubevirtci/fedora-kubeadm:35",
+			"IMAGE_REPO=k8s.gcr.io",
+			"CRI_PATH=/var/run/crio/crio.sock",
+		)
+		stdout, _ := tests.RunCmd(cmd)
+		err := os.WriteFile(manifestsFile, stdout, 0644)
+		Expect(err).To(BeNil())
+
+		By("posting cluster manifests example template")
+		cmd = exec.Command(tests.KubectlPath, "apply", "-f", manifestsFile)
+		tests.RunCmd(cmd)
+
+		By("Waiting for control plane")
+		waitForControlPlane()
+
+		By("Waiting on kubevirt machines to bootstrap")
+		waitForBootstrappedMachines()
 
 		By("Waiting on kubevirt machines to be ready")
-		Eventually(func() error {
-			machineList := &infrav1.KubevirtMachineList{}
-			err = k8sclient.List(context.Background(), machineList, client.InNamespace(namespace))
-			if err != nil {
-				return err
-			}
+		waitForMachineReadiness(2, 0)
 
-			for _, machine := range machineList.Items {
-				if !conditions.IsTrue(&machine, infrav1.BootstrapExecSucceededCondition) {
-					return fmt.Errorf("still waiting on a kubevirt machine with bootstrap succeeded condition")
-				}
+	})
+
+	It("creating a simple cluster with persistent VMs", func() {
+		By("generating cluster manifests from example template")
+		cmd := exec.Command(tests.ClusterctlPath, "generate", "cluster", "kvcluster", "--target-namespace", namespace, "--kubernetes-version", "v1.21.0", "--control-plane-machine-count=1", "--worker-machine-count=1", "--from", "templates/cluster-template-persistent-storage.yaml")
+		cmd.Env = append(os.Environ(),
+			"NODE_VM_IMAGE_TEMPLATE=quay.io/kubevirtci/fedora-kubeadm:35",
+			"IMAGE_REPO=k8s.gcr.io",
+			"CRI_PATH=/var/run/crio/crio.sock",
+		)
+		stdout, _ := tests.RunCmd(cmd)
+		err := os.WriteFile(manifestsFile, stdout, 0644)
+		Expect(err).To(BeNil())
+
+		By("posting cluster manifests example template")
+		cmd = exec.Command(tests.KubectlPath, "apply", "-f", manifestsFile)
+		tests.RunCmd(cmd)
+
+		By("Waiting for control plane")
+		waitForControlPlane()
+
+		By("Waiting on kubevirt machines to bootstrap")
+		waitForBootstrappedMachines()
+
+		By("Waiting on kubevirt machines to be ready")
+		waitForMachineReadiness(2, 0)
+
+		By("Selecting a worker node to restart")
+		vmiList := &kubevirtv1.VirtualMachineInstanceList{}
+		err = k8sclient.List(context.Background(), vmiList, client.InNamespace(namespace))
+		Expect(err).To(BeNil())
+
+		var chosenVMI *kubevirtv1.VirtualMachineInstance
+		for _, vmi := range vmiList.Items {
+			if strings.Contains(vmi.Name, "-md-0") {
+				chosenVMI = &vmi
+				break
 			}
-			return nil
-		}, 5*time.Minute, 5*time.Second).Should(BeNil(), "kubevirt machines should have bootstrap succeeded condition")
+		}
+		Expect(chosenVMI).ToNot(BeNil())
+
+		By(fmt.Sprintf("By restarting worker node hosted in vmi %s", chosenVMI.Name))
+		err = k8sclient.Delete(context.Background(), chosenVMI)
+		Expect(err).To(BeNil())
+
+		By("Expecting a KubevirtMachine to revert back to ready=false while VM restarts")
+		waitForMachineReadiness(1, 1)
+
+		By("Expecting both KubevirtMachines stabilize to a ready=true again.")
+		waitForMachineReadiness(2, 0)
 	})
 })

--- a/kubevirtci
+++ b/kubevirtci
@@ -18,6 +18,7 @@ export KUBEVIRT_DEPLOY_PROMETHEUS=false
 export KUBEVIRT_DEPLOY_CDI=false
 export KUBEVIRT_NUM_NODES=${KUBEVIRT_NUM_NODES:-1}
 export KUBEVIRT_MEMORY_SIZE=${KUBEVIRT_MEMORY_SIZE:-15360M}
+export KUBEVIRT_DEPLOY_CDI="true"
 
 _default_clusterctl_path=./hack/tools/bin/clusterctl
 _default_virtctl_path=./hack/tools/bin/virtctl

--- a/pkg/kubevirt/machine.go
+++ b/pkg/kubevirt/machine.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	infrav1 "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
 	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
 	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/ssh"
 )
@@ -87,8 +88,16 @@ func (m *Machine) Create(ctx gocontext.Context) error {
 		if virtualMachine.Labels == nil {
 			virtualMachine.Labels = map[string]string{}
 		}
+		if virtualMachine.Spec.Template.ObjectMeta.Labels == nil {
+			virtualMachine.Spec.Template.ObjectMeta.Labels = map[string]string{}
+		}
 		virtualMachine.Labels[clusterv1.ClusterLabelName] = m.machineContext.Cluster.Name
 
+		virtualMachine.Labels[infrav1.KubevirtMachineNameLabel] = m.machineContext.KubevirtMachine.Name
+		virtualMachine.Labels[infrav1.KubevirtMachineNamespaceLabel] = m.machineContext.KubevirtMachine.Namespace
+
+		virtualMachine.Spec.Template.ObjectMeta.Labels[infrav1.KubevirtMachineNameLabel] = m.machineContext.KubevirtMachine.Name
+		virtualMachine.Spec.Template.ObjectMeta.Labels[infrav1.KubevirtMachineNamespaceLabel] = m.machineContext.KubevirtMachine.Namespace
 		return nil
 	}
 	if _, err := controllerutil.CreateOrUpdate(ctx, m.client, virtualMachine, mutateFn); err != nil {

--- a/pkg/testing/common.go
+++ b/pkg/testing/common.go
@@ -113,6 +113,19 @@ func NewVirtualMachineInstance(kubevirtMachine *infrav1.KubevirtMachine) *kubevi
 	}
 }
 
+func NewVirtualMachine(vmi *kubevirtv1.VirtualMachineInstance) *kubevirtv1.VirtualMachine {
+	return &kubevirtv1.VirtualMachine{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "VirtualMachine",
+			APIVersion: "kubevirt.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      vmi.Name,
+			Namespace: vmi.Namespace,
+		},
+	}
+}
+
 func NewBootstrapDataSecret(userData []byte) *corev1.Secret {
 	s := &corev1.Secret{}
 	s.Data = make(map[string][]byte)

--- a/templates/cluster-template-persistent-storage.yaml
+++ b/templates/cluster-template-persistent-storage.yaml
@@ -1,0 +1,173 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: "${CLUSTER_NAME}"
+  namespace: "${NAMESPACE}"
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+        - 10.244.0.0/16
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+    kind: KubevirtCluster
+    name: '${CLUSTER_NAME}'
+    namespace: "${NAMESPACE}"
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: '${CLUSTER_NAME}-control-plane'
+    namespace: "${NAMESPACE}"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+kind: KubevirtCluster
+metadata:
+  name: "${CLUSTER_NAME}"
+  namespace: "${NAMESPACE}"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+kind: KubevirtMachineTemplate
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+  namespace: "${NAMESPACE}"
+spec:
+  template:
+    spec:
+      virtualMachineTemplate:
+        spec:
+          dataVolumeTemplates:
+          - metadata:
+              name: "${CLUSTER_NAME}-boot-volume"
+            spec:
+              pvc:
+                accessModes:
+                - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 6Gi
+                storageClassName: local
+              source:
+                registry:
+                  url: "docker://${NODE_VM_IMAGE_TEMPLATE}"
+          runStrategy: Always
+          template:
+            spec:
+              domain:
+                cpu:
+                  cores: 2
+                memory:
+                  guest: "4Gi"
+                devices:
+                  disks:
+                    - disk:
+                        bus: virtio
+                      name: dv-volume
+              volumes:
+                - dataVolume:
+                    name: "${CLUSTER_NAME}-boot-volume"
+                  name: dv-volume
+---
+kind: KubeadmControlPlane
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+  namespace: "${NAMESPACE}"
+spec:
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  machineTemplate:
+    infrastructureRef:
+      kind: KubevirtMachineTemplate
+      apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+      name: "${CLUSTER_NAME}-control-plane"
+      namespace: "${NAMESPACE}"
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      imageRepository: ${IMAGE_REPO}
+    initConfiguration:
+      nodeRegistration:
+        criSocket: "${CRI_PATH}"
+    joinConfiguration:
+      nodeRegistration:
+        criSocket: "{CRI_PATH}"
+  version: "${KUBERNETES_VERSION}"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+kind: KubevirtMachineTemplate
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+  namespace: "${NAMESPACE}"
+spec:
+  template:
+    spec:
+      virtualMachineTemplate:
+        spec:
+          dataVolumeTemplates:
+          - metadata:
+              name: "${CLUSTER_NAME}-boot-volume"
+            spec:
+              pvc:
+                accessModes:
+                - ReadWriteOnce
+                resources:
+                  requests:
+                    storage: 6Gi
+                storageClassName: local
+              source:
+                registry:
+                  url: "docker://${NODE_VM_IMAGE_TEMPLATE}"
+          runStrategy: Always
+          template:
+            spec:
+              domain:
+                cpu:
+                  cores: 2
+                memory:
+                  guest: "4Gi"
+                devices:
+                  disks:
+                    - disk:
+                        bus: virtio
+                      name: dv-volume
+              volumes:
+                - dataVolume:
+                    name: "${CLUSTER_NAME}-boot-volume"
+                  name: dv-volume
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+  namespace: "${NAMESPACE}"
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs: {}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: "${CLUSTER_NAME}-md-0"
+  namespace: "${NAMESPACE}"
+spec:
+  clusterName: "${CLUSTER_NAME}"
+  replicas: ${WORKER_MACHINE_COUNT}
+  selector:
+    matchLabels:
+  template:
+    spec:
+      clusterName: "${CLUSTER_NAME}"
+      version: "${KUBERNETES_VERSION}"
+      bootstrap:
+        configRef:
+          name: "${CLUSTER_NAME}-md-0"
+          namespace: "${NAMESPACE}"
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+      infrastructureRef:
+        name: "${CLUSTER_NAME}-md-0"
+        namespace: "${NAMESPACE}"
+        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
+        kind: KubevirtMachineTemplate

--- a/templates/cluster-template-persistent-storage.yaml
+++ b/templates/cluster-template-persistent-storage.yaml
@@ -35,6 +35,8 @@ spec:
   template:
     spec:
       virtualMachineTemplate:
+        metadata:
+          namespace: "${NAMESPACE}"
         spec:
           dataVolumeTemplates:
           - metadata:
@@ -101,6 +103,8 @@ spec:
   template:
     spec:
       virtualMachineTemplate:
+        metadata:
+          namespace: "${NAMESPACE}"
         spec:
           dataVolumeTemplates:
           - metadata:

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -35,6 +35,8 @@ spec:
   template:
     spec:
       virtualMachineTemplate:
+        metadata:
+          namespace: "${NAMESPACE}"
         spec:
           runStrategy: Always
           template:
@@ -87,6 +89,8 @@ spec:
   template:
     spec:
       virtualMachineTemplate:
+        metadata:
+          namespace: "${NAMESPACE}"
         spec:
           runStrategy: Always
           template:


### PR DESCRIPTION
This PR adds support for continually detecting readiness of a KubeVirtMachine after the initial bootstrapping succeeds. This is needed to properly handle detecting when a VM crashes/fails (via MachineHealthCheck) as well as updating the node IPs when a VM restarts.

## Handling VM Restart
During a restart, the VM's IP will change due to being hosted in a new pod. That IP must be reflected on the KubeVirtMachine object which means we need to continually reconcile the VM in order to detect when such an IP change occurs.

## Handling VM crashes/failures
The KubeVirtMachine.Status.Ready boolean should continually be reconciled after the initial bootstrap completes. This ready boolean on the KubeVirtMachine status translates to the corresponding Machine's ready condition. That ready condition is one of the values commonly used by the [MachineHealthCheck](https://cluster-api.sigs.k8s.io/tasks/healthcheck.html#creating-a-machinehealthcheck) controller to determine if node remediation is necessary or not. 

## Change Summary
* [Bug Fix] Continually reconciles KubeVirtMachines after bootstrapping in order to determine changes to readiness and IPs
* [Enhancement] Adds a new example template for a cluster which uses persistent volumes for VMs
* [Test Coverage] Adds unit and e2e testing to validate clusters using VMs with persistent storage work with node restart.
* [Enhancement] Adds NAMESPACE var to the example templates in order to influence the namespace VMs are created in.

## Implementation Details
The big change here code wise is that the machine controller now watches both VM and VMI objects, and continually reconciles the KubeVirtMachine object even after kubevirtMachine.Status.Ready == true. A few subtle changes occurred to enable this. 

* The controller now fetches both the machine's corresponding VM and VMI. The VM indicates more accurately whether creation needs to occur, and the VMI indicates readiness/IP related details. This prevents situations where we attempt to recreate a VM due to no VMI existing temporarily during a restart.
* After the initial bootstrapping, readiness needs to be set back to false when the VMI is not online for any reason.
* Labels are added to the VM and VMI in order to easily correlate the KubeVirtMachine they belong to. This is used by the Watch() to enqueue KubeVirtMachine's when a VM or VMI is modified. By watching the VM and VMI we can detect when a failure or restart occurs and reconcile the KubeVirtMachine as a result.

```release-note
Adds support for MachineHealthCheck usage
```
