### PR TITLE
fix issue #74

### DIFF
--- a/pkg/kubevirt/utils.go
+++ b/pkg/kubevirt/utils.go
@@ -101,6 +101,7 @@ func newVirtualMachineFromKubevirtMachine(ctx *context.MachineContext, namespace
 	virtualMachine.ObjectMeta.Labels["kubevirt.io/vm"] = ctx.KubevirtMachine.Name
 	virtualMachine.ObjectMeta.Labels["name"] = ctx.KubevirtMachine.Name
 	virtualMachine.ObjectMeta.Labels["cluster.x-k8s.io/role"] = nodeRole(ctx)
+	virtualMachine.ObjectMeta.Labels["cluster.x-k8s.io/cluster-name"] = ctx.Cluster.Name
 
 	// make each datavolume unique by appending machine name as a prefix
 	virtualMachine = prefixDataVolumeTemplates(virtualMachine, ctx.KubevirtMachine.Name)
@@ -137,6 +138,7 @@ func buildVirtualMachineInstanceTemplate(ctx *context.MachineContext) *kubevirtv
 	template.ObjectMeta.Labels["kubevirt.io/vm"] = ctx.KubevirtMachine.Name
 	template.ObjectMeta.Labels["name"] = ctx.KubevirtMachine.Name
 	template.ObjectMeta.Labels["cluster.x-k8s.io/role"] = nodeRole(ctx)
+	template.ObjectMeta.Labels["cluster.x-k8s.io/cluster-name"] = ctx.Cluster.Name
 
 	template.Spec = *ctx.KubevirtMachine.Spec.VirtualMachineTemplate.Spec.Template.Spec.DeepCopy()
 

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -96,6 +96,7 @@ func (l *LoadBalancer) Create(ctx *context.ClusterContext) error {
 			},
 			Selector: map[string]string{
 				"cluster.x-k8s.io/role": constants.ControlPlaneNodeRoleValue,
+				"cluster.x-k8s.io/cluster-name": ctx.Cluster.Name,
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR add another label `cluster.x-k8s.io/cluster-name` for each VM and VMI in workload cluster because existing label `cluster.x-k8s.io/role=control-plane` is not enough to identify different cluster. With existing label works with this new label, now we can identify each workload cluster master node in service selector.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
This PR is resolve issue https://github.com/kubernetes-sigs/cluster-api-provider-kubevirt/issues/74
