### PR TITLE
Fix bug in KubevirtCluster Reconciler - endless reconcile loop with external controller

### DIFF
--- a/controllers/kubevirtcluster_controller.go
+++ b/controllers/kubevirtcluster_controller.go
@@ -210,6 +210,7 @@ func (r *KubevirtClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	c, err := ctrl.NewControllerManagedBy(mgr).
 		For(&infrav1.KubevirtCluster{}).
 		WithEventFilter(predicates.ResourceNotPaused(r.Log)).
+		WithEventFilter(predicates.ResourceIsNotExternallyManaged(r.Log)).
 		Build(r)
 	if err != nil {
 		return err


### PR DESCRIPTION
When the KubevirtCluster CR is manage by an external controller, sometimes there is an update race between capk and the external controller, where each update in one hand, triggers reconcile and update in the other hand and vice versa.

This PR changes that so in this case, the CR is filtered out from the reconciling watch, and so capk will ignore changes made by an external controller.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
