### PR TITLE
Do not wait for SSH keys if there is an external controller

### DIFF
--- a/controllers/kubevirtcluster_controller.go
+++ b/controllers/kubevirtcluster_controller.go
@@ -18,16 +18,12 @@ package controllers
 
 import (
 	gocontext "context"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	infrav1 "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
-	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
-	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/infracluster"
-	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/loadbalancer"
-	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/ssh"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -38,7 +34,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-	"time"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
+	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
+	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/infracluster"
+	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/loadbalancer"
+	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/ssh"
 )
 
 // KubevirtClusterReconciler reconciles a KubevirtCluster object.

--- a/controllers/kubevirtcluster_controller_test.go
+++ b/controllers/kubevirtcluster_controller_test.go
@@ -22,14 +22,14 @@ import (
 )
 
 var (
-	mockCtrl *gomock.Controller
-	clusterName         string
-	kubevirtClusterName string
-	kubevirtCluster     *infrav1.KubevirtCluster
-	cluster             *clusterv1.Cluster
+	mockCtrl                  *gomock.Controller
+	clusterName               string
+	kubevirtClusterName       string
+	kubevirtCluster           *infrav1.KubevirtCluster
+	cluster                   *clusterv1.Cluster
 	fakeClient                client.Client
 	kubevirtClusterReconciler controllers.KubevirtClusterReconciler
-	fakeContext = goContext.TODO()
+	fakeContext               = goContext.TODO()
 )
 
 var _ = Describe("Reconcile", func() {
@@ -38,10 +38,10 @@ var _ = Describe("Reconcile", func() {
 	testLogger := ctrl.Log.WithName("test")
 	setupClient := func(objects []client.Object) {
 		fakeClient = fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
-		kubevirtClusterReconciler = controllers.KubevirtClusterReconciler {
-			Client:          fakeClient,
-			InfraCluster:    infraClusterMock,
-			Log: testLogger,
+		kubevirtClusterReconciler = controllers.KubevirtClusterReconciler{
+			Client:       fakeClient,
+			InfraCluster: infraClusterMock,
+			Log:          testLogger,
 		}
 	}
 	Context("reconcile generic cluster", func() {

--- a/pkg/context/machine_context.go
+++ b/pkg/context/machine_context.go
@@ -22,13 +22,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 
-	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
 	infrav1 "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 // MachineContext is a Go context used with a KubeVirt machine.

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -95,7 +95,7 @@ func (l *LoadBalancer) Create(ctx *context.ClusterContext) error {
 				},
 			},
 			Selector: map[string]string{
-				"cluster.x-k8s.io/role": constants.ControlPlaneNodeRoleValue,
+				"cluster.x-k8s.io/role":         constants.ControlPlaneNodeRoleValue,
 				"cluster.x-k8s.io/cluster-name": ctx.Cluster.Name,
 			},
 		},

--- a/pkg/ssh/cluster_node_ssh_keys.go
+++ b/pkg/ssh/cluster_node_ssh_keys.go
@@ -20,11 +20,12 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clustercontext "sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	clusterutil "sigs.k8s.io/cluster-api/util"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	clustercontext "sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
 )
 
 const (


### PR DESCRIPTION
After stop reconciling KubevirtCluster with external controller, the machine reconcile function is waiting for an SSH keys that are not set anymore, because the cluster reconcile is never called.

To release this block, this PR does two things:

First, it add condition to the machine reconcile, to not wait for SSH keys if there is an external controller.

Then, the implementation of the `KubevirtMachineReconciler.reconcileDelete` function requires an SSH key to build a new machine instance, while the key is not actually used in the deletion process. To ease that, this PR introduces a new version of the `NewMachine` function: the `NewBasicMachine` function. This function creates a new machine instance only with the fields needed for deletion. Then this new function is used in the `NewMachine` function to populate the common fileds, and in the `KubevirtMachineReconciler.reconcileDelete` function to return an instance with fields needed in the deletion process.

Signed-off-by: Alex Gradouski <agradouski@apple.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
