### PR TITLE
Do not wait for SSH keys if there is an external controller

### DIFF
--- a/controllers/kubevirtmachine_controller_test.go
+++ b/controllers/kubevirtmachine_controller_test.go
@@ -422,7 +422,7 @@ var _ = Describe("reconcile a kubevirt machine", func() {
 		Expect(machineContext.KubevirtMachine.Status.Ready).To(BeTrue())
 		out, err := kubevirtMachineReconciler.reconcileNormal(machineContext)
 		Expect(machineContext.KubevirtMachine.Status.Ready).To(BeFalse())
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(out).To(Equal(ctrl.Result{RequeueAfter: 20 * time.Second}))
 	})
 
@@ -446,7 +446,7 @@ var _ = Describe("reconcile a kubevirt machine", func() {
 		Expect(machineContext.KubevirtMachine.Status.Ready).To(BeTrue())
 		out, err := kubevirtMachineReconciler.reconcileNormal(machineContext)
 		Expect(machineContext.KubevirtMachine.Status.Ready).To(BeFalse())
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(out).To(Equal(ctrl.Result{RequeueAfter: 20 * time.Second}))
 	})
 })
@@ -525,7 +525,7 @@ var _ = Describe("updateNodeProviderID", func() {
 		machineContext := &context.MachineContext{KubevirtMachine: kubevirtMachineNotExist, Logger: testLogger}
 		workloadClusterMock.EXPECT().GenerateWorkloadClusterClient(machineContext).Return(fakeWorkloadClusterClient, nil)
 		out, err := kubevirtMachineReconciler.updateNodeProviderID(machineContext)
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 		Expect(out).To(Equal(ctrl.Result{RequeueAfter: 10 * time.Second}))
 		workloadClusterNode := &corev1.Node{}
 		workloadClusterNodeKey := client.ObjectKey{Namespace: kubevirtMachine.Namespace, Name: kubevirtMachine.Name}

--- a/controllers/kubevirtmachine_controller_test.go
+++ b/controllers/kubevirtmachine_controller_test.go
@@ -525,8 +525,8 @@ var _ = Describe("updateNodeProviderID", func() {
 		machineContext := &context.MachineContext{KubevirtMachine: kubevirtMachineNotExist, Logger: testLogger}
 		workloadClusterMock.EXPECT().GenerateWorkloadClusterClient(machineContext).Return(fakeWorkloadClusterClient, nil)
 		out, err := kubevirtMachineReconciler.updateNodeProviderID(machineContext)
-		Expect(err).Should(HaveOccurred())
-		Expect(out).To(Equal(ctrl.Result{RequeueAfter: 5 * time.Second}))
+		Expect(err).To(BeNil())
+		Expect(out).To(Equal(ctrl.Result{RequeueAfter: 10 * time.Second}))
 		workloadClusterNode := &corev1.Node{}
 		workloadClusterNodeKey := client.ObjectKey{Namespace: kubevirtMachine.Namespace, Name: kubevirtMachine.Name}
 		err = fakeWorkloadClusterClient.Get(machineContext, workloadClusterNodeKey, workloadClusterNode)

--- a/e2e-tests/create-cluster_test.go
+++ b/e2e-tests/create-cluster_test.go
@@ -17,13 +17,14 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/rand"
 	kubevirtv1 "kubevirt.io/api/core/v1"
-	infrav1 "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
-	tests "sigs.k8s.io/cluster-api-provider-kubevirt/e2e-tests"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/kind/pkg/cluster/constants"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
+	tests "sigs.k8s.io/cluster-api-provider-kubevirt/e2e-tests"
 )
 
 var _ = Describe("CreateCluster", func() {

--- a/kubevirtci
+++ b/kubevirtci
@@ -20,6 +20,7 @@ export KUBEVIRT_NUM_NODES=${KUBEVIRT_NUM_NODES:-1}
 export KUBEVIRT_MEMORY_SIZE=${KUBEVIRT_MEMORY_SIZE:-15360M}
 export KUBEVIRT_DEPLOY_CDI="true"
 
+_default_bin_path=./hack/tools/bin
 _default_clusterctl_path=./hack/tools/bin/clusterctl
 _default_virtctl_path=./hack/tools/bin/virtctl
 
@@ -60,7 +61,13 @@ function kubevirtci::up() {
 	${_kubectl} apply -f https://github.com/kubevirt/kubevirt/releases/download/${LATEST}/kubevirt-operator.yaml
 	${_kubectl} apply -f https://github.com/kubevirt/kubevirt/releases/download/${LATEST}/kubevirt-cr.yaml
 	echo "installing capi..."
-	$CLUSTERCTL_PATH init
+
+	cat << EOF > ${_default_bin_path}/clusterctl_config.yaml
+---
+cert-manager:
+  url: "https://github.com/cert-manager/cert-manager/releases/latest/cert-manager.yaml"
+EOF
+	$CLUSTERCTL_PATH init -v 4 --config=${_default_bin_path}/clusterctl_config.yaml
 	echo "waiting for kubevirt to become ready, this can take a few minutes. You can safely abort this step, the cluster is ready ..."
 	${_kubectl} -n kubevirt wait kv kubevirt --for condition=Available --timeout=5m
 }

--- a/pkg/kubevirt/machine.go
+++ b/pkg/kubevirt/machine.go
@@ -165,7 +165,7 @@ func (m *Machine) SupportsCheckingIsBootstrapped() bool {
 
 // IsBootstrapped checks if the VM is bootstrapped with Kubernetes.
 func (m *Machine) IsBootstrapped() bool {
-	if !m.IsReady() {
+	if !m.IsReady() || m.sshKeys == nil {
 		return false
 	}
 


### PR DESCRIPTION
When a KubeVirt Cluster object is managed by an external controller (meaning not by our capk cluster controller) then the ssh keys generated by our capk cluster controller in order to introspect VM guests will not be present. The machine controller needs to know and expect that these ssh keys won't be available when the cluster is externaly managed and still process the VM.

This PR also addresses timing issues with how a worker node's provider ID doesn't always get set in certain situations when external clusters are in use.

In addition to the logical fixes, unit tests and e2e functional tests have been added to exercise the external cluster behavior. I had to add a new workaround for our e2e test suite setup that sources cert-manager from the new cert-manager repo. This addressed a new bug in clusterctl that caused `clusterctl init` to fail.