### PR TITLE
Pass the GOPROXY variable properly to docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ docker-pull-prerequisites:
 
 .PHONY: docker-build
 docker-build: docker-pull-prerequisites ## Build the docker image for controller-manager
-	DOCKER_BUILDKIT=1 docker build --build-arg goproxy=$(GOPROXY) --build-arg ARCH=$(ARCH) . -t $(CONTROLLER_IMG)-$(ARCH):$(TAG) --file Dockerfile
+	DOCKER_BUILDKIT=1 docker build --build-arg goproxy="$(GOPROXY)" --build-arg ARCH=$(ARCH) . -t $(CONTROLLER_IMG)-$(ARCH):$(TAG) --file Dockerfile
 	MANIFEST_IMG=$(CONTROLLER_IMG)-$(ARCH) MANIFEST_TAG=$(TAG) $(MAKE) set-manifest-image
 	$(MAKE) set-manifest-pull-policy
 


### PR DESCRIPTION
GOPROXY variables can container `|`s. In order to properly pass GOPROXY to docker, it has to be quoted.


KubeVirt CI passes now a GORPOXY variable like this: `https://proxy.golang.org|https://goproxy.io|direct`. See https://github.com/kubevirt/project-infra/pull/1885 for more context.