### PR TITLE
Add go-linter to the github action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,6 +19,7 @@ jobs:
       run: make test
     - name: Build
       run: make manager
+
   coverage:
     if: (github.repository == 'kubernetes-sigs/cluster-api-provider-kubevirt')
     runs-on: ubuntu-latest
@@ -41,3 +42,12 @@ jobs:
       run: |-
         GO111MODULE=off go get github.com/mattn/goveralls
         $(go env GOPATH)/bin/goveralls -coverprofile=coverprofiles/cover.coverprofile -service=github
+
+  go-linter:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v2
+      with: # TODO: remove this when the deprecated function will be removed (issue #85)
+        args: --exclude SA1019

--- a/e2e-tests/create-cluster_test.go
+++ b/e2e-tests/create-cluster_test.go
@@ -49,9 +49,9 @@ var _ = Describe("CreateCluster", func() {
 		k8sclient, err = client.New(cfg, client.Options{})
 		Expect(err).To(BeNil())
 
-		clusterv1.AddToScheme(k8sclient.Scheme())
-		infrav1.AddToScheme(k8sclient.Scheme())
-		kubevirtv1.AddToScheme(k8sclient.Scheme())
+		_ = clusterv1.AddToScheme(k8sclient.Scheme())
+		_ = infrav1.AddToScheme(k8sclient.Scheme())
+		_ = kubevirtv1.AddToScheme(k8sclient.Scheme())
 
 		namespace = "e2e-test-create-cluster-" + rand.String(6)
 
@@ -74,8 +74,8 @@ var _ = Describe("CreateCluster", func() {
 					Name: namespace,
 				},
 			}
-			k8sclient.Delete(context.Background(), ns)
-			os.RemoveAll(tmpDir)
+			_ = k8sclient.Delete(context.Background(), ns)
+			_ = os.RemoveAll(tmpDir)
 		}()
 
 		// Typically the machine deployment and machines should not need to get removed before

--- a/pkg/kubevirt/machine.go
+++ b/pkg/kubevirt/machine.go
@@ -147,11 +147,7 @@ func (m *Machine) Address() string {
 
 // IsReady checks if the VM is ready
 func (m *Machine) IsReady() bool {
-	if !m.hasReadyCondition() {
-		return false
-	}
-
-	return true
+	return m.hasReadyCondition()
 }
 
 // SupportsCheckingIsBootstrapped checks if we have a method of checking
@@ -199,7 +195,7 @@ func (m *Machine) Delete() error {
 	vm := &kubevirtv1.VirtualMachine{}
 	if err := m.client.Get(m.machineContext.Context, namespacedName, vm); err != nil {
 		if apierrors.IsNotFound(err) {
-			m.machineContext.Logger.Info(fmt.Sprintf("VM does not exist, nothing to do."))
+			m.machineContext.Logger.Info("VM does not exist, nothing to do.")
 			return nil
 		}
 	}

--- a/pkg/kubevirt/machine_test.go
+++ b/pkg/kubevirt/machine_test.go
@@ -246,6 +246,7 @@ var _ = Describe("With KubeVirt VM running", func() {
 		externalMachine, err := defaultTestMachine(machineContext, fakeClient, fakeVMCommandExecutor, []byte(sshKey))
 		Expect(err).NotTo(HaveOccurred())
 		providerId, err := externalMachine.GenerateProviderID()
+		Expect(err).ToNot(HaveOccurred())
 		Expect(providerId).To(Equal(expectedProviderId))
 	})
 

--- a/pkg/kubevirt/utils.go
+++ b/pkg/kubevirt/utils.go
@@ -27,11 +27,6 @@ import (
 	"sigs.k8s.io/kind/pkg/cluster/constants"
 )
 
-const (
-	clusterLabelKey  = "io.x-k8s.capk.cluster"
-	nodeRoleLabelKey = "io.x-k8s.capk.role"
-)
-
 type CommandExecutor interface {
 	ExecuteCommand(command string) (string, error)
 }
@@ -46,7 +41,7 @@ func prefixDataVolumeTemplates(vm *kubevirtv1.VirtualMachine, prefix string) *ku
 	}
 
 	dvNameMap := map[string]string{}
-	for i, _ := range vm.Spec.DataVolumeTemplates {
+	for i := range vm.Spec.DataVolumeTemplates {
 
 		prefixedName := fmt.Sprintf("%s-%s", prefix, vm.Spec.DataVolumeTemplates[i].Name)
 		dvNameMap[vm.Spec.DataVolumeTemplates[i].Name] = prefixedName

--- a/pkg/ssh/ssh_command_executor.go
+++ b/pkg/ssh/ssh_command_executor.go
@@ -47,6 +47,9 @@ func NewVMCommandExecutor(address string, keys *ClusterNodeSshKeys) VMCommandExe
 func (e vmCommandExecutor) ExecuteCommand(command string) (string, error) {
 	// create signer
 	signer, err := signerFromPem(e.PrivateKey, []byte(""))
+	if err != nil {
+		return "", fmt.Errorf("can't get signer from PEM; %w", err)
+	}
 
 	sshConfig := &ssh.ClientConfig{
 		User: "capk",

--- a/pkg/ssh/utils.go
+++ b/pkg/ssh/utils.go
@@ -105,7 +105,7 @@ func signerFromPem(pemBytes []byte, password []byte) (ssh.Signer, error) {
 	// handle encrypted key
 	if x509.IsEncryptedPEMBlock(pemBlock) {
 		// decrypt PEM
-		pemBlock.Bytes, err = x509.DecryptPEMBlock(pemBlock, []byte(password))
+		pemBlock.Bytes, err = x509.DecryptPEMBlock(pemBlock, password)
 		if err != nil {
 			return nil, fmt.Errorf("Decrypting PEM block failed %v", err)
 		}


### PR DESCRIPTION
Fix all the golangci-linter warning (except for two deprecated function calls) and add the linter as a github action and a merge gate.

There are still two warning excluded from linter run, because of two deprecated function calls. see details here #85 

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
