### PR TITLE
Sort the imports and reformat all golang files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,3 +29,8 @@ Custom Information - if you're copying this template for the first time you can 
 - [Mailing list](URL)
 
 -->
+
+## Opening a New Pull Request
+Before pushing a pull request, please run `make sanity` and check that it passed.
+
+This command may change some files. If that happened, you'll need to commit these files before pushing them to the remote repository.

--- a/Makefile
+++ b/Makefile
@@ -266,3 +266,17 @@ verify-gen: generate
 .PHONY: functest
 functest:
 	./hack/functest.sh
+
+.PHONY: goimports
+goimports:
+	go install golang.org/x/tools/cmd/goimports@latest
+	goimports -w -local="sigs.k8s.io/cluster-api-provider-kubevirt"  $(shell find . -type f -name '*.go' ! -path "*/vendor/*" ! -path "./_kubevirtci/*" ! -path "*zz_generated*" )
+
+.PHONY: linter
+linter:
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	# todo remove the exclude parameter when issue #85 is resolved
+	golangci-lint run --exclude SA1019
+
+.PHONY: sanity
+sanity: linter goimports test

--- a/controllers/kubevirtcluster_controller.go
+++ b/controllers/kubevirtcluster_controller.go
@@ -18,16 +18,12 @@ package controllers
 
 import (
 	gocontext "context"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	infrav1 "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
-	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
-	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/infracluster"
-	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/loadbalancer"
-	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/ssh"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -38,7 +34,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-	"time"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
+	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
+	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/infracluster"
+	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/loadbalancer"
+	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/ssh"
 )
 
 // KubevirtClusterReconciler reconciles a KubevirtCluster object.

--- a/controllers/kubevirtcluster_controller_test.go
+++ b/controllers/kubevirtcluster_controller_test.go
@@ -2,6 +2,8 @@ package controllers_test
 
 import (
 	goContext "context"
+	"time"
+
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -9,27 +11,27 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubevirtv1 "kubevirt.io/api/core/v1"
-	infrav1 "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
-	"sigs.k8s.io/cluster-api-provider-kubevirt/controllers"
-	infraclustermock "sigs.k8s.io/cluster-api-provider-kubevirt/pkg/infracluster/mock"
-	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/testing"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	. "sigs.k8s.io/controller-runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"time"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
+	"sigs.k8s.io/cluster-api-provider-kubevirt/controllers"
+	infraclustermock "sigs.k8s.io/cluster-api-provider-kubevirt/pkg/infracluster/mock"
+	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/testing"
 )
 
 var (
-	mockCtrl *gomock.Controller
-	clusterName         string
-	kubevirtClusterName string
-	kubevirtCluster     *infrav1.KubevirtCluster
-	cluster             *clusterv1.Cluster
+	mockCtrl                  *gomock.Controller
+	clusterName               string
+	kubevirtClusterName       string
+	kubevirtCluster           *infrav1.KubevirtCluster
+	cluster                   *clusterv1.Cluster
 	fakeClient                client.Client
 	kubevirtClusterReconciler controllers.KubevirtClusterReconciler
-	fakeContext = goContext.TODO()
+	fakeContext               = goContext.TODO()
 )
 
 var _ = Describe("Reconcile", func() {
@@ -38,10 +40,10 @@ var _ = Describe("Reconcile", func() {
 	testLogger := ctrl.Log.WithName("test")
 	setupClient := func(objects []client.Object) {
 		fakeClient = fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
-		kubevirtClusterReconciler = controllers.KubevirtClusterReconciler {
-			Client:          fakeClient,
-			InfraCluster:    infraClusterMock,
-			Log: testLogger,
+		kubevirtClusterReconciler = controllers.KubevirtClusterReconciler{
+			Client:       fakeClient,
+			InfraCluster: infraClusterMock,
+			Log:          testLogger,
 		}
 	}
 	Context("reconcile generic cluster", func() {

--- a/controllers/kubevirtmachine_controller.go
+++ b/controllers/kubevirtmachine_controller.go
@@ -28,6 +28,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	kubevirtv1 "kubevirt.io/api/core/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -40,7 +41,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	kubevirtv1 "kubevirt.io/api/core/v1"
 	infrav1 "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
 	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
 	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/infracluster"

--- a/controllers/kubevirtmachine_controller_test.go
+++ b/controllers/kubevirtmachine_controller_test.go
@@ -25,20 +25,20 @@ import (
 	"github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
-	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
-	infraclustermock "sigs.k8s.io/cluster-api-provider-kubevirt/pkg/infracluster/mock"
-	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/testing"
-	workloadclustermock "sigs.k8s.io/cluster-api-provider-kubevirt/pkg/workloadcluster/mock"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubevirtv1 "kubevirt.io/api/core/v1"
-	infrav1 "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
+	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
+	infraclustermock "sigs.k8s.io/cluster-api-provider-kubevirt/pkg/infracluster/mock"
+	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/testing"
+	workloadclustermock "sigs.k8s.io/cluster-api-provider-kubevirt/pkg/workloadcluster/mock"
 )
 
 var (

--- a/controllers/kubevirtmachine_suite_test.go
+++ b/controllers/kubevirtmachine_suite_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package controllers
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"testing"
 )
 
 func TestKubevirtMachineController(t *testing.T) {

--- a/e2e-tests/create-cluster_test.go
+++ b/e2e-tests/create-cluster_test.go
@@ -12,17 +12,17 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 	kubevirtv1 "kubevirt.io/api/core/v1"
-	infrav1 "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
-	tests "sigs.k8s.io/cluster-api-provider-kubevirt/e2e-tests"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
+	tests "sigs.k8s.io/cluster-api-provider-kubevirt/e2e-tests"
 )
 
 var _ = Describe("CreateCluster", func() {

--- a/hack/tools/tools.go
+++ b/hack/tools/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 /*

--- a/main.go
+++ b/main.go
@@ -23,13 +23,7 @@ import (
 	"os"
 	"time"
 
-	"sigs.k8s.io/cluster-api-provider-kubevirt/controllers"
-	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/infracluster"
-	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/workloadcluster"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
-
 	"github.com/spf13/pflag"
-
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -37,11 +31,16 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"
 	kubevirtv1 "kubevirt.io/api/core/v1"
-	infrav1 "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/feature"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
+	"sigs.k8s.io/cluster-api-provider-kubevirt/controllers"
+	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/infracluster"
+	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/workloadcluster"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/pkg/context/cluster_context.go
+++ b/pkg/context/cluster_context.go
@@ -20,12 +20,12 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-logr/logr"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 
-	"github.com/go-logr/logr"
 	infrav1 "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 // ClusterContext is a Go context used with a KubeVirt cluster.

--- a/pkg/context/machine_context.go
+++ b/pkg/context/machine_context.go
@@ -22,13 +22,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 
-	"github.com/go-logr/logr"
-	corev1 "k8s.io/api/core/v1"
 	infrav1 "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 
 // MachineContext is a Go context used with a KubeVirt machine.

--- a/pkg/infracluster/infracluster.go
+++ b/pkg/infracluster/infracluster.go
@@ -1,12 +1,14 @@
 package infracluster
 
 import (
+	"strings"
+
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/clientcmd"
-	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
+
+	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
 )
 
 //go:generate mockgen -source=./infracluster.go -destination=./mock/infracluster_generated.go -package=mock

--- a/pkg/infracluster/mock/infracluster_generated.go
+++ b/pkg/infracluster/mock/infracluster_generated.go
@@ -5,11 +5,12 @@
 package mock
 
 import (
-	reflect "reflect"
+	"reflect"
 
-	gomock "github.com/golang/mock/gomock"
-	context "sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
-	client "sigs.k8s.io/controller-runtime/pkg/client"
+	"github.com/golang/mock/gomock"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
 )
 
 // MockInfraCluster is a mock of InfraCluster interface.

--- a/pkg/kubevirt/kubevirt_suite_test.go
+++ b/pkg/kubevirt/kubevirt_suite_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package kubevirt
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"testing"
 )
 
 func TestKubevirt(t *testing.T) {

--- a/pkg/kubevirt/utils.go
+++ b/pkg/kubevirt/utils.go
@@ -22,9 +22,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubevirtv1 "kubevirt.io/api/core/v1"
-	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/kind/pkg/cluster/constants"
+
+	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
 )
 
 type CommandExecutor interface {

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -18,18 +18,19 @@ package loadbalancer
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
-	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 
+	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	infrav1 "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
-	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlutil "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/kind/pkg/cluster/constants"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
+	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
 )
 
 // LoadBalancer manages the load balancer for a specific KubeVirt cluster.
@@ -95,7 +96,7 @@ func (l *LoadBalancer) Create(ctx *context.ClusterContext) error {
 				},
 			},
 			Selector: map[string]string{
-				"cluster.x-k8s.io/role": constants.ControlPlaneNodeRoleValue,
+				"cluster.x-k8s.io/role":         constants.ControlPlaneNodeRoleValue,
 				"cluster.x-k8s.io/cluster-name": ctx.Cluster.Name,
 			},
 		},

--- a/pkg/loadbalancer/loadbalancer_suite_test.go
+++ b/pkg/loadbalancer/loadbalancer_suite_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package loadbalancer_test
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"testing"
 )
 
 func TestLoadBalancer(t *testing.T) {

--- a/pkg/loadbalancer/loadbalancer_test.go
+++ b/pkg/loadbalancer/loadbalancer_test.go
@@ -19,22 +19,21 @@ package loadbalancer_test
 import (
 	gocontext "context"
 
-	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/testing"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
-	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/loadbalancer"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubevirtv1 "kubevirt.io/api/core/v1"
-	infrav1 "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
+	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
+	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/loadbalancer"
+	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/testing"
 )
 
 var (

--- a/pkg/ssh/cluster_node_ssh_keys.go
+++ b/pkg/ssh/cluster_node_ssh_keys.go
@@ -20,11 +20,12 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clustercontext "sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	clusterutil "sigs.k8s.io/cluster-api/util"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	clustercontext "sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
 )
 
 const (

--- a/pkg/ssh/cluster_node_ssh_keys_test.go
+++ b/pkg/ssh/cluster_node_ssh_keys_test.go
@@ -5,18 +5,18 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	kubevirtv1 "kubevirt.io/api/core/v1"
-	infrav1 "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
-	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
-	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/ssh"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/testing"
+	kubevirtv1 "kubevirt.io/api/core/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
+	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
+	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/ssh"
+	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/testing"
 )
 
 var (

--- a/pkg/testing/common.go
+++ b/pkg/testing/common.go
@@ -4,8 +4,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubevirtv1 "kubevirt.io/api/core/v1"
-	infrav1 "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
 )
 
 func NewCluster(clusterName string, kubevirtCluster *infrav1.KubevirtCluster) *clusterv1.Cluster {

--- a/pkg/workloadcluster/mock/workloadcluster_generated.go
+++ b/pkg/workloadcluster/mock/workloadcluster_generated.go
@@ -8,8 +8,9 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	context "sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
+
+	context "sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
 )
 
 // MockWorkloadCluster is a mock of WorkloadCluster interface

--- a/pkg/workloadcluster/workloadcluster.go
+++ b/pkg/workloadcluster/workloadcluster.go
@@ -4,8 +4,9 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/clientcmd"
-	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
 )
 
 //go:generate mockgen -source=./workloadcluster.go -destination=./mock/workloadcluster_generated.go -package=mock


### PR DESCRIPTION
This PR is a result of running goimports. Many golang files are affected from that, changing their order of imports and code format.

The PR also adds the `make goimpots`, `make linter` and `make sanity`.

The last one contain the other two and also running the unit tests. 

It is expected from a PR author to run `make sanity` before pushing the PR.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
