### PR TITLE
returen external IP address for loadbalancer

### DIFF
--- a/controllers/kubevirtcluster_controller.go
+++ b/controllers/kubevirtcluster_controller.go
@@ -141,19 +141,29 @@ func (r *KubevirtClusterReconciler) reconcileNormal(ctx *context.ClusterContext,
 		}
 	}
 
-	// Wait 10 seconds for LoadBalancer to assign external IP after been created
-	time.Sleep(10 * time.Second)
+	// Get LoadBalancer ExternalIP if cluster Service Type is LoadBalancer
+	if ctx.KubevirtCluster.Spec.ControlPlaneServiceTemplate.Spec.Type == "LoadBalancer" {
+		lbip4, err := externalLoadBalancer.ExternalIP(ctx)
+		if err != nil {
+			conditions.MarkFalse(ctx.KubevirtCluster, infrav1.LoadBalancerAvailableCondition, infrav1.LoadBalancerProvisioningFailedReason, clusterv1.ConditionSeverityWarning, err.Error())
+			return ctrl.Result{}, errors.Wrap(err, "failed to get ExternalIP for the load balancer")
+		}
+		ctx.KubevirtCluster.Spec.ControlPlaneEndpoint = infrav1.APIEndpoint{
+			Host: lbip4,
+			Port: 6443,
+		}
 
-	// Set APIEndpoints with the load balancer IP so the Cluster API Cluster Controller can pull it
-	lbip4, err := externalLoadBalancer.IP(ctx)
-	if err != nil {
-		conditions.MarkFalse(ctx.KubevirtCluster, infrav1.LoadBalancerAvailableCondition, infrav1.LoadBalancerProvisioningFailedReason, clusterv1.ConditionSeverityWarning, err.Error())
-		return ctrl.Result{}, errors.Wrap(err, "failed to get IP for the load balancer")
-	}
-
-	ctx.KubevirtCluster.Spec.ControlPlaneEndpoint = infrav1.APIEndpoint{
-		Host: lbip4,
-		Port: 6443,
+	// Get Cluster IP if cluster Service Type is CusterIP
+	} else {
+		lbip4, err := externalLoadBalancer.IP(ctx)
+		if err != nil {
+			conditions.MarkFalse(ctx.KubevirtCluster, infrav1.LoadBalancerAvailableCondition, infrav1.LoadBalancerProvisioningFailedReason, clusterv1.ConditionSeverityWarning, err.Error())
+			return ctrl.Result{}, errors.Wrap(err, "failed to get ClusterIP for the load balancer")
+		}
+		ctx.KubevirtCluster.Spec.ControlPlaneEndpoint = infrav1.APIEndpoint{
+			Host: lbip4,
+			Port: 6443,
+		}
 	}
 
 	conditions.MarkTrue(ctx.KubevirtCluster, infrav1.LoadBalancerAvailableCondition)

--- a/controllers/kubevirtcluster_controller.go
+++ b/controllers/kubevirtcluster_controller.go
@@ -141,7 +141,7 @@ func (r *KubevirtClusterReconciler) reconcileNormal(ctx *context.ClusterContext,
 		}
 	}
 
-	// Add 10 seconds delay for loadbalancer to assign external IP
+	// Wait 10 seconds for LoadBalancer to assign external IP after been created
 	time.Sleep(10 * time.Second)
 
 	// Set APIEndpoints with the load balancer IP so the Cluster API Cluster Controller can pull it

--- a/controllers/kubevirtcluster_controller.go
+++ b/controllers/kubevirtcluster_controller.go
@@ -141,6 +141,9 @@ func (r *KubevirtClusterReconciler) reconcileNormal(ctx *context.ClusterContext,
 		}
 	}
 
+	// Add 10 seconds delay for loadbalancer to assign external IP
+	time.Sleep(10 * time.Second)
+
 	// Set APIEndpoints with the load balancer IP so the Cluster API Cluster Controller can pull it
 	lbip4, err := externalLoadBalancer.IP(ctx)
 	if err != nil {

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -132,11 +132,17 @@ func (l *LoadBalancer) IP(ctx *context.ClusterContext) (string, error) {
 		return "", err
 	}
 
-	if len(loadBalancer.Spec.ClusterIP) == 0 {
-		return "", fmt.Errorf("the load balancer service is not ready yet")
-	}
+	if len(loadBalancer.Status.LoadBalancer.Ingress) == 0 {
+		ctx.Logger.Info("can not get LoadBalancer external IP address, trying to get ClusterIP address")
 
-	return loadBalancer.Spec.ClusterIP, nil
+		if len(loadBalancer.Spec.ClusterIP) == 0 {
+			return "", fmt.Errorf("the load balancer service is not ready yet")
+		}
+
+		return loadBalancer.Spec.ClusterIP, nil
+	}
+	ctx.Logger.Info("return Loadbalancer external IP address")
+	return loadBalancer.Status.LoadBalancer.Ingress[0].IP, nil
 }
 
 // Delete deletes load-balancer service.


### PR DESCRIPTION
**What this PR does / why we need it**:
Return external IP if LoadBalancer type service enabled for API endpoint.

Also add 10 seconds delay for loadbalancer to assign external IP after LB created, otherwise, may return ClusterIP incorrectly.