### PR TITLE
Fix a unit test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,4 +50,4 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v2
       with: # TODO: remove this when the deprecated function will be removed (issue #85)
-        args: --exclude SA1019
+        args: --exclude SA1019 --timeout=5m

--- a/controllers/kubevirtmachine_controller_test.go
+++ b/controllers/kubevirtmachine_controller_test.go
@@ -346,8 +346,7 @@ var _ = Describe("reconcile a kubevirt machine", func() {
 
 		setupClient(machineFactoryMock, objects)
 
-		clusterContext := &context.ClusterContext{Context: machineContext.Context, Cluster: machineContext.Cluster, KubevirtCluster: machineContext.KubevirtCluster, Logger: machineContext.Logger}
-		infraClusterMock.EXPECT().GenerateInfraClusterClient(clusterContext).Return(fakeClient, cluster.Namespace, nil).Times(1)
+		infraClusterMock.EXPECT().GenerateInfraClusterClient(machineContext.KubevirtMachine.Spec.InfraClusterSecretRef, machineContext.KubevirtMachine.Namespace, machineContext.Context).Return(fakeClient, cluster.Namespace, nil).Times(1)
 
 		out, err := kubevirtMachineReconciler.reconcileDelete(machineContext)
 		Expect(err).ShouldNot(HaveOccurred())


### PR DESCRIPTION
the "should ensure deletion of KubevirtMachine when bootstrap secret was never created" unit test is failed to be compiled.

This PR fixes the mock expect call, so now the test is compiled, run and passed

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
