### PR TITLE
Added integration with the image-builder kubevirt image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ $(KUSTOMIZE): # Build kustomize from tools folder.
 	$(MAKE) -C $(ROOT) kustomize
 
 # Define Docker related variables. Releases should modify and double check these vars.
-REGISTRY ?= localhost:5000
+REGISTRY ?= 127.0.0.1:5000
 IMAGE_NAME ?= capk-manager
 CONTROLLER_IMG ?= $(REGISTRY)/$(IMAGE_NAME)
 ARCH ?= amd64

--- a/e2e/create-cluster_test.go
+++ b/e2e/create-cluster_test.go
@@ -107,7 +107,7 @@ var _ = Describe("CreateCluster", func() {
 				}
 			}
 			return nil
-		}, 5*time.Minute, 5*time.Second).Should(Succeed(), "kubevirt machines should have bootstrap succeeded condition")
+		}, 10*time.Minute, 5*time.Second).Should(Succeed(), "kubevirt machines should have bootstrap succeeded condition")
 
 	}
 
@@ -275,7 +275,7 @@ var _ = Describe("CreateCluster", func() {
 			}
 
 			return nil
-		}, 10*time.Minute, 5*time.Second).Should(Succeed(), "cluster should have control plane initialized")
+		}, 15*time.Minute, 5*time.Second).Should(Succeed(), "cluster should have control plane initialized")
 	}
 
 	injectKubevirtClusterExternallyManagedAnnotation := func(yamlStr string) string {

--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -13,10 +13,10 @@ echo "Building and installing capk manager container"
 
 echo "Running e2e test suite"
 export KUBECONFIG=$(./kubevirtci kubeconfig)
-export NODE_VM_IMAGE_TEMPLATE=quay.io/kubevirtci/fedora-kubeadm:35
+export NODE_VM_IMAGE_TEMPLATE=quay.io/capk/ubuntu-container-disk:20.04
 export IMAGE_REPO=k8s.gcr.io
 export TENANT_CLUSTER_KUBERNETES_VERSION=v1.21.0
-export CRI_PATH=/var/run/crio/crio.sock
+export CRI_PATH=/var/run/containerd/containerd.sock
 export ROOT_VOLUME_SIZE=23Gi
 export STORAGE_CLASS_NAME=rook-ceph-block
 make e2e-test

--- a/kubevirtci
+++ b/kubevirtci
@@ -78,7 +78,7 @@ function kubevirtci::down() {
 }
 
 function kubevirtci::build() {
-	export REGISTRY="localhost:$(cluster-up/cluster-up/cli.sh ports registry)"
+	export REGISTRY="127.0.0.1:$(cluster-up/cluster-up/cli.sh ports registry)"
 	make docker-build
 	make docker-push
 }
@@ -104,9 +104,9 @@ function kubevirtci::generate_kubeconfig() {
 }
 
 function kubevirtci::create_cluster() {
-	export NODE_VM_IMAGE_TEMPLATE=quay.io/kubevirtci/fedora-kubeadm:35
+	export NODE_VM_IMAGE_TEMPLATE=quay.io/capk/ubuntu-container-disk:20.04
 	export IMAGE_REPO=k8s.gcr.io
-	export CRI_PATH="/var/run/crio/crio.sock"
+	export CRI_PATH="/var/run/containerd/containerd.sock"
 	oc create secret generic external-infra-kubeconfig -n capk-system --from-file=kubeconfig=kubeconfig-e2e --from-literal=namespace=e2e-test
 	$CLUSTERCTL_PATH generate cluster kvcluster --kubernetes-version v1.21.0 --control-plane-machine-count=1 --worker-machine-count=1 --from templates/cluster-template-ext-infra.yaml | ${_kubectl} apply -f -
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
I created a kubevirt target in my fork of the image-builder project:
https://github.com/isaacdorfman/image-builder/tree/kubevirt-target

This image is the image of the machines in the cluster.
I pushed the image I built in my image-builder fork into quay and updated the capk to use this image instead of the kubevirtci one.
In this PR I also fixed the problems that this change caused.
*I also fixed a problem with the local container reigstry by changing the url of the registry from localhost to 127.0.0.1, this caused problems related to ipv6 in some devices.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
