### PR TITLE
Fix typo in kubevirtci::fetch_kubevirtci

### DIFF
--- a/kubevirtci
+++ b/kubevirtci
@@ -38,7 +38,7 @@ function kubevirtci::kubeconfig() {
 
 function kubevirtci::fetch_kubevirtci() {
 	[[ -d cluster-up ]] || git clone https://github.com/kubevirt/kubevirtci.git cluster-up
-	(cd cluster-up && git checkout ${KUEVIRTCI_TAG} > /dev/null)
+	(cd cluster-up && git checkout ${KUBEVIRTCI_TAG} > /dev/null)
 	mkdir -p ./hack/tools/bin/
 	if [ ! -f "${_default_clusterctl_path}" ]; then
 		echo >&2 "Downloading clusterctl ..."


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Fix typo in kubevirtci::fetch_kubevirtci

KUEVIRTCI_TAG --> KUBEVIRTCI_TAG

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
