### PR TITLE
Fix clusterkubevirtadm-linux-amd64 calling from e2e cluster creation workflow

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -31,8 +31,8 @@ jobs:
           KUBECONFIG: ${{secrets.KUBECONFIG}}
       - name: create credentials
         run: |-
-          bin/clusterkubevirtadm-linux-amd64 create credentials --cluster-name=2e2-test
-          bin/clusterkubevirtadm-linux-amd64 get credentials --cluster-name=2e2-test --output-kubeconfig="${GITHUB_WORKSPACE}/project-infra/.kubeconfig-e2e"
+          bin/clusterkubevirtadm-linux-amd64 create credentials --namespace e2e-test
+          bin/clusterkubevirtadm-linux-amd64 get kubeconfig --namespace=e2e-test --output-kubeconfig="${GITHUB_WORKSPACE}/project-infra/.kubeconfig-e2e"
         env:
           KUBECONFIG: ${GITHUB_WORKSPACE}/project-infra/.kubeconfig
       - name: Test


### PR DESCRIPTION

**What this PR does / why we need it**:
Fix clusterkubevirtadm-linux-amd64 calling from e2e cluster creation workflow
