### PR TITLE
Switch to using rook-ceph for e2e storage class

### DIFF
--- a/e2e-tests/create-cluster_test.go
+++ b/e2e-tests/create-cluster_test.go
@@ -366,6 +366,8 @@ var _ = Describe("CreateCluster", func() {
 			"NODE_VM_IMAGE_TEMPLATE=quay.io/kubevirtci/fedora-kubeadm:35",
 			"IMAGE_REPO=k8s.gcr.io",
 			"CRI_PATH=/var/run/crio/crio.sock",
+			"ROOT_VOLUME_SIZE=23Gi",
+			"STORAGE_CLASS_NAME=rook-ceph-block",
 		)
 		stdout, _ := tests.RunCmd(cmd)
 		err := os.WriteFile(manifestsFile, stdout, 0644)

--- a/kubevirtci
+++ b/kubevirtci
@@ -19,6 +19,7 @@ export KUBEVIRT_DEPLOY_CDI=false
 export KUBEVIRT_NUM_NODES=${KUBEVIRT_NUM_NODES:-1}
 export KUBEVIRT_MEMORY_SIZE=${KUBEVIRT_MEMORY_SIZE:-15360M}
 export KUBEVIRT_DEPLOY_CDI="true"
+export KUBEVIRT_STORAGE="rook-ceph-default"
 
 _default_bin_path=./hack/tools/bin
 _default_clusterctl_path=./hack/tools/bin/clusterctl

--- a/templates/cluster-template-persistent-storage.yaml
+++ b/templates/cluster-template-persistent-storage.yaml
@@ -50,8 +50,8 @@ spec:
                 - ReadWriteOnce
                 resources:
                   requests:
-                    storage: 6Gi
-                storageClassName: local
+                    storage: "${ROOT_VOLUME_SIZE}"
+                storageClassName: "${STORAGE_CLASS_NAME}"
               source:
                 registry:
                   url: "docker://${NODE_VM_IMAGE_TEMPLATE}"
@@ -118,8 +118,8 @@ spec:
                 - ReadWriteOnce
                 resources:
                   requests:
-                    storage: 6Gi
-                storageClassName: local
+                    storage: "${ROOT_VOLUME_SIZE}"
+                storageClassName: "${STORAGE_CLASS_NAME}"
               source:
                 registry:
                   url: "docker://${NODE_VM_IMAGE_TEMPLATE}"


### PR DESCRIPTION
This PR exposes storage class and volume size as tunables for the persistent storage template. It also transitions us to using rook-ceph for kubevirt ci storage.

We needed to switch to rook-ceph because we hit some limitations with how big of a volume we could provision using local storage. This resolves those limitations which will allow us to use the new image builder images @isaacdorfman  is working on in PR #108 


```release-note
NONE
```
