### PR TITLE
Add failure printout to the e2e test RunCmd function

### DIFF
--- a/e2e/common_test.go
+++ b/e2e/common_test.go
@@ -45,8 +45,7 @@ func RunCmd(cmd *exec.Cmd) (stdoutBytes []byte, stderrBytes []byte) {
 	cmd.Stderr = stderr
 
 	// run the command
-	err := cmd.Run()
-	Expect(err).To(BeNil())
+	ExpectWithOffset(1, cmd.Run()).To(Succeed(), fmt.Sprintf("failed to run %s, with arguments: %v; error response: %s", cmd.Path, cmd.Args, stderr.Bytes()))
 
 	return stdout.Bytes(), stderr.Bytes()
 }


### PR DESCRIPTION
In order to debug e2e test failures, add failure printout to the `RunCmd`
function, so we could understand what went wrong in case of a failure.

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

-->
```release-note
None
```
