### PR TITLE
Kubevirtci updates

### DIFF
--- a/kubevirtci
+++ b/kubevirtci
@@ -145,7 +145,7 @@ function kubevirtci::kubectl_tenant {
     ${_default_virtctl_path} port-forward -n ${TENANT_CLUSTER_NAMESPACE} vm/${control_plane_vm_name} 64443:6443 > /dev/null 2>&1 &
     trap 'kill $(jobs -p) > /dev/null 2>&1' EXIT
     rm -f .${TENANT_CLUSTER_NAME}-kubeconfig
-    $CLUSTERCTL_PATH get kubeconfig ${TENANT_CLUSTER_NAME} > .${TENANT_CLUSTER_NAME}-kubeconfig
+    $CLUSTERCTL_PATH get kubeconfig ${TENANT_CLUSTER_NAME} -n ${TENANT_CLUSTER_NAMESPACE} > .${TENANT_CLUSTER_NAME}-kubeconfig
     sleep 0.1
     kubectl --kubeconfig .${TENANT_CLUSTER_NAME}-kubeconfig --insecure-skip-tls-verify --server https://localhost:64443 "$@"
 }

--- a/kubevirtci
+++ b/kubevirtci
@@ -48,6 +48,7 @@ function kubevirtci::usage() {
 	  ssh-infra <node name>             SSH into one of the infra nodes (like node01)
 	  ssh-tenant <vmi> [vmi namespace]  SSH into one of the guest nodes
 	  create-cluster                    Create new kubernetes tenant cluster
+	  destroy-cluster                   Destroy the tenant cluster
 	  kubectl-tenant <kubectl options>  Interact with the tenant cluster
 
 	  help                              Print usage
@@ -141,11 +142,15 @@ function kubevirtci::generate_kubeconfig() {
         sed -i -r 's/127.0.0.1:[0-9]+/192.168.66.101:6443/g' kubeconfig-e2e
 }
 
+function kubevirtci::destroy_cluster() {
+	${_kubectl} delete cluster -n ${TENANT_CLUSTER_NAMESPACE} ${TENANT_CLUSTER_NAME}
+}
+
 function kubevirtci::create_cluster() {
 	export NODE_VM_IMAGE_TEMPLATE=quay.io/capk/ubuntu-container-disk:20.04
 	export IMAGE_REPO=k8s.gcr.io
 	export CRI_PATH="/var/run/containerd/containerd.sock"
-	oc create secret generic external-infra-kubeconfig -n capk-system --from-file=kubeconfig=kubeconfig-e2e --from-literal=namespace=${TENANT_CLUSTER_NAMESPACE}
+	${_kubectl} create secret generic external-infra-kubeconfig -n capk-system --from-file=kubeconfig=kubeconfig-e2e --from-literal=namespace=${TENANT_CLUSTER_NAMESPACE}
 	$CLUSTERCTL_PATH generate cluster ${TENANT_CLUSTER_NAME} --kubernetes-version v1.21.0 --control-plane-machine-count=1 --worker-machine-count=1 --from templates/cluster-template-ext-infra.yaml | ${_kubectl} apply -f -
 }
 
@@ -212,6 +217,9 @@ case ${_action} in
 "create-cluster")
 	kubevirtci::generate_kubeconfig
 	kubevirtci::create_cluster
+	;;
+"destroy-cluster")
+	kubevirtci::destroy_cluster
 	;;
 "help")
 	kubevirtci::usage

--- a/kubevirtci
+++ b/kubevirtci
@@ -42,14 +42,15 @@ function kubevirtci::usage() {
 
 	  kubeconfig                        Return the kubeconfig of the cluster
 	  kubectl <kubectl options>         Interact with the cluster
+	  kubectl-tenant <kubectl options>  Interact with the tenant cluster
 	  virtctl <virtctl options>         Run virtctl commands against the cluster
 	  clusterctl <clusterctl options>   Run clusterctl commands against the cluster
 
 	  ssh-infra <node name>             SSH into one of the infra nodes (like node01)
 	  ssh-tenant <vmi> [vmi namespace]  SSH into one of the guest nodes
 	  create-cluster                    Create new kubernetes tenant cluster
+	  create-external-cluster           Create new kubernetes tenant cluster simulated as running on external infra
 	  destroy-cluster                   Destroy the tenant cluster
-	  kubectl-tenant <kubectl options>  Interact with the tenant cluster
 
 	  help                              Print usage
 	"
@@ -113,7 +114,7 @@ function kubevirtci::ssh_tenant() {
 
 	echo "vmi $vmi_name namespace $vmi_namespace"
 
-	${_kubectl} get secret -n e2e-test-create-cluster-87mlkk kvcluster-ssh-keys -o jsonpath='{.data}' | grep key | awk -F '"' '{print $4}' | base64 -d > ${_default_tmp_path}/key.pem
+	${_kubectl} get secret -n $TENANT_CLUSTER_NAMESPACE kvcluster-ssh-keys -o jsonpath='{.data}' | grep key | awk -F '"' '{print $4}' | base64 -d > ${_default_tmp_path}/key.pem
 
 	chmod 600 ${_default_tmp_path}/key.pem
 
@@ -143,15 +144,25 @@ function kubevirtci::generate_kubeconfig() {
 }
 
 function kubevirtci::destroy_cluster() {
-	${_kubectl} delete cluster -n ${TENANT_CLUSTER_NAMESPACE} ${TENANT_CLUSTER_NAME}
+	${_kubectl} delete cluster -n ${TENANT_CLUSTER_NAMESPACE} ${TENANT_CLUSTER_NAME} --ignore-not-found
 }
 
 function kubevirtci::create_cluster() {
 	export NODE_VM_IMAGE_TEMPLATE=quay.io/capk/ubuntu-container-disk:20.04
 	export IMAGE_REPO=k8s.gcr.io
 	export CRI_PATH="/var/run/containerd/containerd.sock"
+
+	$CLUSTERCTL_PATH generate cluster ${TENANT_CLUSTER_NAME} --target-namespace ${TENANT_CLUSTER_NAMESPACE} --kubernetes-version v1.21.0 --control-plane-machine-count=1 --worker-machine-count=1 --from templates/cluster-template.yaml | ${_kubectl} apply -f -
+}
+
+function kubevirtci::create_external_cluster() {
+	export NODE_VM_IMAGE_TEMPLATE=quay.io/capk/ubuntu-container-disk:20.04
+	export IMAGE_REPO=k8s.gcr.io
+	export CRI_PATH="/var/run/containerd/containerd.sock"
+
+	${_kubectl} delete secret external-infra-kubeconfig -n capk-system --ignore-not-found
 	${_kubectl} create secret generic external-infra-kubeconfig -n capk-system --from-file=kubeconfig=kubeconfig-e2e --from-literal=namespace=${TENANT_CLUSTER_NAMESPACE}
-	$CLUSTERCTL_PATH generate cluster ${TENANT_CLUSTER_NAME} --kubernetes-version v1.21.0 --control-plane-machine-count=1 --worker-machine-count=1 --from templates/cluster-template-ext-infra.yaml | ${_kubectl} apply -f -
+	$CLUSTERCTL_PATH generate cluster ${TENANT_CLUSTER_NAME} --target-namespace ${TENANT_CLUSTER_NAMESPACE} --kubernetes-version v1.21.0 --control-plane-machine-count=1 --worker-machine-count=1 --from templates/cluster-template-ext-infra.yaml | ${_kubectl} apply -f -
 }
 
 function kubevirtci::kubectl_tenant {
@@ -215,8 +226,11 @@ case ${_action} in
 	$CLUSTERCTL_PATH "$@"
 	;;
 "create-cluster")
-	kubevirtci::generate_kubeconfig
 	kubevirtci::create_cluster
+	;;
+"create-external-cluster")
+	kubevirtci::generate_kubeconfig
+	kubevirtci::create_external_cluster
 	;;
 "destroy-cluster")
 	kubevirtci::destroy_cluster

--- a/kubevirtci
+++ b/kubevirtci
@@ -13,6 +13,7 @@ export KUBEVIRT_DEPLOY_CDI="true"
 export KUBEVIRT_STORAGE="rook-ceph-default"
 
 _default_bin_path=./hack/tools/bin
+_default_tmp_path=./hack/tools/bin/tmp
 _default_clusterctl_path=./hack/tools/bin/clusterctl
 _default_virtctl_path=./hack/tools/bin/virtctl
 
@@ -21,6 +22,7 @@ export TENANT_CLUSTER_NAME=${TENANT_CLUSTER_NAME:-kvcluster}
 export TENANT_CLUSTER_NAMESPACE=${TENANT_CLUSTER_NAMESPACE:-kvcluster}
 
 _kubectl=cluster-up/cluster-up/kubectl.sh
+_ssh_infra=cluster-up/cluster-up/ssh.sh
 
 _action=$1
 shift
@@ -43,6 +45,8 @@ function kubevirtci::usage() {
 	  virtctl <virtctl options>         Run virtctl commands against the cluster
 	  clusterctl <clusterctl options>   Run clusterctl commands against the cluster
 
+	  ssh-infra <node name>             SSH into one of the infra nodes (like node01)
+	  ssh-tenant <vmi> [vmi namespace]  SSH into one of the guest nodes
 	  create-cluster                    Create new kubernetes tenant cluster
 	  kubectl-tenant <kubectl options>  Interact with the tenant cluster
 
@@ -98,6 +102,23 @@ function kubevirtci::build() {
 	export REGISTRY="127.0.0.1:$(cluster-up/cluster-up/cli.sh ports registry)"
 	make docker-build
 	make docker-push
+}
+
+function kubevirtci::ssh_tenant() {
+	vmi_name=$1
+	vmi_namespace=${2:-$TENANT_CLUSTER_NAMESPACE}
+
+	mkdir -p $_default_tmp_path
+
+	echo "vmi $vmi_name namespace $vmi_namespace"
+
+	${_kubectl} get secret -n e2e-test-create-cluster-87mlkk kvcluster-ssh-keys -o jsonpath='{.data}' | grep key | awk -F '"' '{print $4}' | base64 -d > ${_default_tmp_path}/key.pem
+
+	chmod 600 ${_default_tmp_path}/key.pem
+
+	ssh -o IdentitiesOnly=yes -o "ProxyCommand=$_default_virtctl_path port-forward --stdio=true $vmi_name.$vmi_namespace 22" capk@$vmi_name.$vmi_namespace -i ${_default_tmp_path}/key.pem
+
+	rm ${_default_tmp_path}/key.pem
 }
 
 function kubevirtci::refresh() {
@@ -178,6 +199,12 @@ case ${_action} in
 	;;
 "virtctl")
 	${_default_virtctl_path} "$@"
+	;;
+"ssh-infra")
+	$_ssh_infra "$@"
+	;;
+"ssh-tenant")
+	kubevirtci::ssh_tenant "$@"
 	;;
 "clusterctl")
 	$CLUSTERCTL_PATH "$@"


### PR DESCRIPTION
This updates the kubevirtci script to include the following changes
- adds ssh commands for accessing tenant and infra nodes
- adds a destroy-cluster command
- separates create-cluster into two commands, create-cluster and create-external-cluster. The new create-external-cluster command simulates an external cluster using the clusterkubevirtadm command. The normal create-cluster commands treats the infra and management as the same cluster.
- adds the namespace to the create-cluster command so clusters are created in the $TENANT_CLUSTER_NAMESPACE instead of the default namespace.
- fixes the new `kubectl-tenant` command to look in the $TENANT_CLUSTER_NAMESPACE when finding the guest cluster's kubeconfig


```release-note
NONE
```
