### PR TITLE
Kubevirtci metal lb support

### DIFF
--- a/kubevirtci
+++ b/kubevirtci
@@ -11,8 +11,9 @@ export KUBEVIRT_NUM_NODES=${KUBEVIRT_NUM_NODES:-1}
 export KUBEVIRT_MEMORY_SIZE=${KUBEVIRT_MEMORY_SIZE:-15360M}
 export KUBEVIRT_DEPLOY_CDI="true"
 export KUBEVIRT_STORAGE="rook-ceph-default"
-export KUBEVIRT_METALLB_VERSION="v0.12.1"
-
+export METALLB_VERSION="v0.12.1"
+export CAPK_RELEASE_VERSION="v0.1.0-rc.0"
+export CLUSTERCTL_VERSION="v1.0.0"
 
 _default_bin_path=./hack/tools/bin
 _default_tmp_path=./hack/tools/bin/tmp
@@ -38,7 +39,7 @@ function kubevirtci::usage() {
 	Commands:
 
 	  up                                Start a cluster with kubevirt, cert-manager and capi
-	  sync                              Build and deploy current capk
+	  sync                              Build and deploy current capk from source (must be executed from within capk source tree)
 	  down                              Destroy the cluster
 	  refresh                           Build current capk and trigger creating new capk pods
 
@@ -48,6 +49,7 @@ function kubevirtci::usage() {
 	  virtctl <virtctl options>         Run virtctl commands against the cluster
 	  clusterctl <clusterctl options>   Run clusterctl commands against the cluster
 
+	  install-capk                      Installs capk from published release manifests
 	  install-metallb                   Installs metallb into the infra cluster
 	  curl-lb <lb name> [lb namespace]  Curls lb service within infra cluster
 
@@ -67,11 +69,11 @@ function kubevirtci::kubeconfig() {
 
 function kubevirtci::fetch_kubevirtci() {
 	[[ -d cluster-up ]] || git clone https://github.com/kubevirt/kubevirtci.git cluster-up
-	(cd cluster-up && git checkout ${KUBEVIRTCI_TAG} > /dev/null)
+	(cd cluster-up && git checkout main > /dev/null 2>&1 && git pull > /dev/null && git checkout ${KUBEVIRTCI_TAG} > /dev/null 2>&1)
 	mkdir -p ./hack/tools/bin/
 	if [ ! -f "${_default_clusterctl_path}" ]; then
-		echo >&2 "Downloading clusterctl ..."
-		curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.0/clusterctl-linux-amd64 -o ${_default_clusterctl_path}
+		echo >&2 "Downloading clusterctl version ${CLUSTERCTL_VERSION}..."
+		curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/${CLUSTERCTL_VERSION}/clusterctl-linux-amd64 -o ${_default_clusterctl_path}
 		chmod u+x ${_default_clusterctl_path}
 	fi
 	if [ ! -f "${_default_virtctl_path}" ]; then
@@ -156,8 +158,15 @@ function kubevirtci::create_cluster() {
 	export NODE_VM_IMAGE_TEMPLATE=quay.io/capk/ubuntu-container-disk:20.04
 	export IMAGE_REPO=k8s.gcr.io
 	export CRI_PATH="/var/run/containerd/containerd.sock"
+	template=templates/cluster-template.yaml
 
-	$CLUSTERCTL_PATH generate cluster ${TENANT_CLUSTER_NAME} --target-namespace ${TENANT_CLUSTER_NAMESPACE} --kubernetes-version v1.21.0 --control-plane-machine-count=1 --worker-machine-count=1 --from templates/cluster-template.yaml | ${_kubectl} apply -f -
+	if [ ! -f $template ]; then
+		template="https://github.com/kubernetes-sigs/cluster-api-provider-kubevirt/blob/main/templates/cluster-template.yaml"
+	fi
+
+	echo "Using cluster template $template"
+
+	$CLUSTERCTL_PATH generate cluster ${TENANT_CLUSTER_NAME} --target-namespace ${TENANT_CLUSTER_NAMESPACE} --kubernetes-version v1.21.0 --control-plane-machine-count=1 --worker-machine-count=1 --from $template | ${_kubectl} apply -f -
 }
 
 function kubevirtci::create_external_cluster() {
@@ -170,10 +179,27 @@ function kubevirtci::create_external_cluster() {
 	$CLUSTERCTL_PATH generate cluster ${TENANT_CLUSTER_NAME} --target-namespace ${TENANT_CLUSTER_NAMESPACE} --kubernetes-version v1.21.0 --control-plane-machine-count=1 --worker-machine-count=1 --from templates/cluster-template-ext-infra.yaml | ${_kubectl} apply -f -
 }
 
+function kubevirtci::create_tenant_namespace {
+	${_kubectl} apply -f - <<EOF
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ${TENANT_CLUSTER_NAMESPACE}
+EOF
+}
+
+function kubevirtci::install_capk_release {
+	${_kubectl} apply -f https://github.com/kubernetes-sigs/cluster-api-provider-kubevirt/releases/download/${CAPK_RELEASE_VERSION}/infrastructure-components.yaml
+
+	${_kubectl} wait -n capk-system --for=condition=Available=true deployment/capk-controller-manager --timeout=10m
+
+	echo "capk release $CAPK_RELEASE_VERSION installed!"
+}
 
 function kubevirtci::install_metallb {
-	${_kubectl} apply -f https://raw.githubusercontent.com/metallb/metallb/${KUBEVIRT_METALLB_VERSION}/manifests/namespace.yaml
-	${_kubectl} apply -f https://raw.githubusercontent.com/metallb/metallb/${KUBEVIRT_METALLB_VERSION}/manifests/metallb.yaml
+	${_kubectl} apply -f https://raw.githubusercontent.com/metallb/metallb/${METALLB_VERSION}/manifests/namespace.yaml
+	${_kubectl} apply -f https://raw.githubusercontent.com/metallb/metallb/${METALLB_VERSION}/manifests/metallb.yaml
 
 	echo "waiting for metallb to come online"
 	${_kubectl} -n metallb-system wait deployment controller --for condition=Available --timeout=5m
@@ -291,7 +317,9 @@ case ${_action} in
 	kubevirtci::build
 	kubevirtci::install
 	;;
-
+"install-capk")
+	kubevirtci::install_capk_release
+	;;
 "install-metallb")
 	kubevirtci::install_metallb
 	;;
@@ -320,9 +348,11 @@ case ${_action} in
 	$CLUSTERCTL_PATH "$@"
 	;;
 "create-cluster")
+	kubevirtci::create_tenant_namespace
 	kubevirtci::create_cluster
 	;;
 "create-external-cluster")
+	kubevirtci::create_tenant_namespace
 	kubevirtci::generate_kubeconfig
 	kubevirtci::create_external_cluster
 	;;

--- a/kubevirtci
+++ b/kubevirtci
@@ -42,6 +42,7 @@ function kubevirtci::usage() {
 	  sync                              Build and deploy current capk from source (must be executed from within capk source tree)
 	  down                              Destroy the cluster
 	  refresh                           Build current capk and trigger creating new capk pods
+	  clean-cache                       Removes all files cached by kubevirtci
 
 	  kubeconfig                        Return the kubeconfig of the cluster
 	  kubectl <kubectl options>         Interact with the cluster
@@ -358,6 +359,12 @@ case ${_action} in
 	;;
 "destroy-cluster")
 	kubevirtci::destroy_cluster
+	;;
+
+"clean-cache")
+	rm ${_default_clusterctl_path}
+	rm ${_default_virtctl_path}
+	rm -rf ${_default_tmp_path}
 	;;
 "help")
 	kubevirtci::usage

--- a/kubevirtci
+++ b/kubevirtci
@@ -49,7 +49,7 @@ function kubevirtci::usage() {
 	  clusterctl <clusterctl options>   Run clusterctl commands against the cluster
 
 	  install-metallb                   Installs metallb into the infra cluster
-	  curl-lb                           Curls lb service within infra cluster
+	  curl-lb <lb name> [lb namespace]  Curls lb service within infra cluster
 
 	  ssh-infra <node name>             SSH into one of the infra nodes (like node01)
 	  ssh-tenant <vmi> [vmi namespace]  SSH into one of the guest nodes
@@ -174,6 +174,8 @@ function kubevirtci::create_external_cluster() {
 function kubevirtci::install_metallb {
 	${_kubectl} apply -f https://raw.githubusercontent.com/metallb/metallb/${KUBEVIRT_METALLB_VERSION}/manifests/namespace.yaml
 	${_kubectl} apply -f https://raw.githubusercontent.com/metallb/metallb/${KUBEVIRT_METALLB_VERSION}/manifests/metallb.yaml
+
+	echo "waiting for metallb to come online"
 	${_kubectl} -n metallb-system wait deployment controller --for condition=Available --timeout=5m
 
 	mkdir -p ${_default_tmp_path}
@@ -198,7 +200,57 @@ EOF
 	${_kubectl} apply -f ${metal_config}
 
 	rm $metal_config
+	echo "metallb installed!"
 }
+
+function kubevirtci::curl_lb {
+	mkdir -p ${_default_tmp_path}
+	job_yaml=${_default_tmp_path}/curl-test-pod.yaml
+	if [ -f ${job_yaml} ]; then
+		${_kubectl} delete -f ${job_yaml} --ignore-not-found
+	fi
+
+	lb_name=$1
+	lb_namespace=${2:-$TENANT_CLUSTER_NAMESPACE}
+
+	$_kubectl get service $lb_name -n $lb_namespace
+
+	lb_ip=$($_kubectl get service $lb_name -n $lb_namespace -o yaml | grep "ip:" | awk '{print $3}')
+	lb_port=$($_kubectl get service $lb_name -n $lb_namespace -o yaml | grep "port:" | awk '{print $2}')
+
+
+	cat << EOF > $job_yaml
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: curl-test-job
+  namespace: ${lb_namespace}
+spec:
+  template:
+    spec:
+      containers:
+      - name: fedora
+        image: fedora:35
+        command:
+          - curl
+          - "${lb_ip}:${lb_port}"
+      restartPolicy: Never
+  backoffLimit: 4
+EOF
+
+	${_kubectl} create -f $job_yaml
+	echo "-----------Waiting for curl job to complete"
+	${_kubectl} wait job curl-test-job -n default --for condition=Complete --timeout=5m
+
+	pod_name=$($_kubectl get pods --selector=job-name=curl-test-job --output=jsonpath='{.items[*].metadata.name}')
+
+	echo "-----------CURL LOG FOR POD $pod_name"
+	$_kubectl logs -n default $pod_name 2>/dev/null
+
+	${_kubectl} delete -f ${job_yaml} --ignore-not-found > /dev/null 2>&1
+}
+
 
 function kubevirtci::kubectl_tenant {
     vms_list=$(${_kubectl} get vm -n ${TENANT_CLUSTER_NAMESPACE} --no-headers -o custom-columns=":metadata.name")
@@ -242,6 +294,9 @@ case ${_action} in
 
 "install-metallb")
 	kubevirtci::install_metallb
+	;;
+"curl-lb")
+	kubevirtci::curl_lb "$@"
 	;;
 "kubeconfig")
 	kubevirtci::kubeconfig

--- a/kubevirtci
+++ b/kubevirtci
@@ -11,6 +11,8 @@ export KUBEVIRT_NUM_NODES=${KUBEVIRT_NUM_NODES:-1}
 export KUBEVIRT_MEMORY_SIZE=${KUBEVIRT_MEMORY_SIZE:-15360M}
 export KUBEVIRT_DEPLOY_CDI="true"
 export KUBEVIRT_STORAGE="rook-ceph-default"
+export KUBEVIRT_METALLB_VERSION="v0.12.1"
+
 
 _default_bin_path=./hack/tools/bin
 _default_tmp_path=./hack/tools/bin/tmp
@@ -45,6 +47,9 @@ function kubevirtci::usage() {
 	  kubectl-tenant <kubectl options>  Interact with the tenant cluster
 	  virtctl <virtctl options>         Run virtctl commands against the cluster
 	  clusterctl <clusterctl options>   Run clusterctl commands against the cluster
+
+	  install-metallb                   Installs metallb into the infra cluster
+	  curl-lb                           Curls lb service within infra cluster
 
 	  ssh-infra <node name>             SSH into one of the infra nodes (like node01)
 	  ssh-tenant <vmi> [vmi namespace]  SSH into one of the guest nodes
@@ -165,6 +170,36 @@ function kubevirtci::create_external_cluster() {
 	$CLUSTERCTL_PATH generate cluster ${TENANT_CLUSTER_NAME} --target-namespace ${TENANT_CLUSTER_NAMESPACE} --kubernetes-version v1.21.0 --control-plane-machine-count=1 --worker-machine-count=1 --from templates/cluster-template-ext-infra.yaml | ${_kubectl} apply -f -
 }
 
+
+function kubevirtci::install_metallb {
+	${_kubectl} apply -f https://raw.githubusercontent.com/metallb/metallb/${KUBEVIRT_METALLB_VERSION}/manifests/namespace.yaml
+	${_kubectl} apply -f https://raw.githubusercontent.com/metallb/metallb/${KUBEVIRT_METALLB_VERSION}/manifests/metallb.yaml
+	${_kubectl} -n metallb-system wait deployment controller --for condition=Available --timeout=5m
+
+	mkdir -p ${_default_tmp_path}
+	local metal_config=${_default_tmp_path}/metallb-config.yaml
+
+	cat << EOF > $metal_config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - 192.168.66.201-192.168.66.250
+EOF
+
+	${_kubectl} apply -f ${metal_config}
+
+	rm $metal_config
+}
+
 function kubevirtci::kubectl_tenant {
     vms_list=$(${_kubectl} get vm -n ${TENANT_CLUSTER_NAMESPACE} --no-headers -o custom-columns=":metadata.name")
     for vm in $vms_list
@@ -203,6 +238,10 @@ case ${_action} in
 "sync")
 	kubevirtci::build
 	kubevirtci::install
+	;;
+
+"install-metallb")
+	kubevirtci::install_metallb
 	;;
 "kubeconfig")
 	kubevirtci::kubeconfig


### PR DESCRIPTION
This PR adds two new commands

```./kubevirtci install-metallb``` which installs and configures a metallb instance in the kubevirtci cluster
```./kubevirtci curl-lb <lb name> <lb namespace>``` Which curls the load balancer services external ip and port then dumps the log output to stdout.
```./kubevirtci install-capk``` which installs capk from the release manifests instead of source. This allows the kubevirtci script to be used outside of the capk source tree (like in cloud-provider-kubevirt or kubevirt csi)
```./kubevirtci clean-cache``` which cleans the local clusterctl, virtctl, and tmp files used by kubevirtci


# Example
Install metal lb
```
./kubevirtci install-metallb
```

Post these pods and LB service to the infra cluster
```
kind: Pod
apiVersion: v1
metadata:
  name: foo-app
  labels:
    app: http-echo
spec:
  containers:
  - name: foo-app
    image: hashicorp/http-echo:0.2.3
    args:
    - "-text=foo"
---
kind: Pod
apiVersion: v1
metadata:
  name: bar-app
  labels:
    app: http-echo
spec:
  containers:
  - name: bar-app
    image: hashicorp/http-echo:0.2.3
    args:
    - "-text=bar"
---
kind: Service
apiVersion: v1
metadata:
  name: foo-service
spec:
  type: LoadBalancer
  selector:
    app: http-echo
  ports:
  # Default port used by the image
  - port: 5678
```

Run kubevirtci curl-lb foo-service default and view the curl's output log
```
$ ./kubevirtci curl-lb foo-service default
HEAD is now at 8198e9c sync provider.sh between kind and kind-sriov (#587)
selecting docker as container runtime
selecting docker as container runtime
NAME          TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)          AGE
foo-service   LoadBalancer   10.100.78.53   192.168.66.201   5678:30579/TCP   2m14s
selecting docker as container runtime
selecting docker as container runtime
selecting docker as container runtime
job.batch/curl-test-job created
-----------Waiting for curl job to complete
selecting docker as container runtime
job.batch/curl-test-job condition met
selecting docker as container runtime
-----------CURL LOG FOR POD curl-test-job-hb554
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100     4  100     4    0     0   2015      0 --:--:-- --:--:-- --:--:--  4000
foo
```
```release-note
NONE
```
