### PR TITLE
Fix flaky e2e test

### DIFF
--- a/e2e/create-cluster_test.go
+++ b/e2e/create-cluster_test.go
@@ -23,6 +23,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/kind/pkg/cluster/constants"
@@ -580,11 +581,15 @@ var _ = Describe("CreateCluster", func() {
 		chosenVMI := chooseWorkerVMI()
 
 		By("Setting terminal state on VMI")
+		patchHelper, err := patch.NewHelper(chosenVMI, k8sclient)
+		Expect(err).ToNot(HaveOccurred())
+
 		kvmName, ok := chosenVMI.Labels["capk.cluster.x-k8s.io/kubevirt-machine-name"]
 		Expect(ok).To(BeTrue())
 
 		chosenVMI.Labels[infrav1.KubevirtMachineVMTerminalLabel] = "marked-terminal-by-func-test"
-		chosenVMI, err = virtClient.VirtualMachineInstance(namespace).Update(chosenVMI)
+
+		err = patchHelper.Patch(context.Background(), chosenVMI)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Wait for KubeVirtMachine is deleted due to remediation")
@@ -650,13 +655,17 @@ var _ = Describe("CreateCluster", func() {
 		chosenVMI := chooseWorkerVMI()
 
 		By("Setting VM to runstrategy once")
+
+		patchHelper, err := patch.NewHelper(chosenVMI, k8sclient)
+		Expect(err).ToNot(HaveOccurred())
+
 		chosenVM, err := virtClient.VirtualMachine(chosenVMI.Namespace).Get(chosenVMI.Name, &metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
 		once := kubevirtv1.RunStrategyOnce
 		chosenVM.Spec.RunStrategy = &once
 
-		_, err = virtClient.VirtualMachine(namespace).Update(chosenVM)
+		err = patchHelper.Patch(context.Background(), chosenVMI)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("killing the chosen VMI's pod")


### PR DESCRIPTION
These tests occasionally failed because the Update() vmi call returned an err. This err occurred because the vmi would mutate between the Get and Update calls. To fix this, we use a Patch

```release-note
NONE
```
