### PR TITLE
e2e: use getLocalPort method

### DIFF
--- a/e2e/common_test.go
+++ b/e2e/common_test.go
@@ -75,7 +75,7 @@ func newTenantClusterAccess(namespace string, tenantKubeconfigFile string) tenan
 }
 
 func (t *tenantClusterAccess) generateClient() (*kubernetes.Clientset, error) {
-	localPort := t.listener.Addr().(*net.TCPAddr).Port
+	localPort := t.getLocalPort()
 	cmd := exec.Command(ClusterctlPath, "get", "kubeconfig", "kvcluster",
 		"--namespace", t.namespace)
 	stdout, _ := RunCmd(cmd)


### PR DESCRIPTION

Signed-off-by: Radim Hrazdil <rhrazdil@redhat.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
This PR uses already implemented `t.getLocalPort` method instead of
 calling `t.listener.Addr().(*net.TCPAddr).Port`


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
