### PR TITLE
test, reporter: Integrate with kubevirt dump

### DIFF
--- a/e2e/e2e-suite_test.go
+++ b/e2e/e2e-suite_test.go
@@ -1,9 +1,13 @@
 package e2e_test
 
 import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"os"
 
 	"flag"
 	"testing"
@@ -12,12 +16,14 @@ import (
 // Test suite required arguments
 var KubectlPath string
 var ClusterctlPath string
+var DumpPath string
 var WorkingDir string
 
 // Initialize test required arguments
 func init() {
 	flag.StringVar(&KubectlPath, "kubectl-path", "", "Path to the kubectl binary")
 	flag.StringVar(&ClusterctlPath, "clusterctl-path", "", "Path to the clusterctl binary")
+	flag.StringVar(&DumpPath, "dump-path", "", "Path to the kubevirt artifacts dump cmd binary")
 	flag.StringVar(&WorkingDir, "working-dir", "", "Path used for e2e test files")
 }
 
@@ -38,6 +44,11 @@ func TestE2E(t *testing.T) {
 	} else if _, err := os.Stat(WorkingDir); os.IsNotExist(err) {
 		t.Fatalf("invalid working-dir path: %s doesn't exist", WorkingDir)
 	}
+	if DumpPath != "" {
+		if _, err := os.Stat(DumpPath); os.IsNotExist(err) {
+			t.Fatalf("invalid dump-path: %s doesn't exist", DumpPath)
+		}
+	}
 
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "E2E Suite")
@@ -47,3 +58,21 @@ var _ = BeforeSuite(func() {
 	// parse test suite arguments
 	flag.Parse()
 })
+
+var _ = JustAfterEach(func() {
+	if CurrentSpecReport().Failed() && DumpPath != "" {
+		dump(os.Getenv("KUBECONFIG"), "")
+	}
+})
+
+func dump(kubeconfig, artifactsSuffix string) {
+	cmd := exec.Command(DumpPath, "--kubeconfig", kubeconfig)
+
+	failureLocation := CurrentSpecReport().Failure.Location
+	artifactsPath := filepath.Join(os.Getenv("ARTIFACTS"), fmt.Sprintf("%s:%d", filepath.Base(failureLocation.FileName), failureLocation.LineNumber), artifactsSuffix)
+	cmd.Env = append(cmd.Env, fmt.Sprintf("ARTIFACTS=%s", artifactsPath))
+
+	By(fmt.Sprintf("dumping k8s artifacts to %s", artifactsPath))
+	output, err := cmd.CombinedOutput()
+	Expect(err).ToNot(HaveOccurred(), string(output))
+}

--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -6,7 +6,16 @@ TOOLS_DIR=${TOOLS_DIR:-hack/tools}
 
 CLUSTERCTL_PATH=${TOOLS_DIR}/bin/clusterctl
 KUBECTL_PATH=${TOOLS_DIR}/bin/kubectl
+DUMP_VERSION=$(curl -L https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/latest)
+DUMP_PATH=${TOOLS_DIR}/bin/kubevirt-${DUMP_VERSION}-dump
 TEST_WORKING_DIR=${TOOLS_DIR}/e2e-test-workingdir
+export ARTIFACTS=${ARTIFACTS:-k8s-reporter}
+mkdir -p $ARTIFACTS
+
+if [ ! -f "$DUMP_PATH" ]; then
+    curl -L https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/${version}/testing/dump -o $DUMP_PATH
+    chmod 755 $DUMP_PATH
+fi
 
 if [ ! -f "${CLUSTERCTL_PATH}" ]; then
 	echo >&2 "Downloading clusterctl ..."
@@ -22,4 +31,4 @@ fi
 
 rm -rf $TEST_WORKING_DIR
 mkdir -p $TEST_WORKING_DIR
-$BIN_DIR/e2e.test -ginkgo.v --kubectl-path $KUBECTL_PATH --clusterctl-path $CLUSTERCTL_PATH --working-dir $TEST_WORKING_DIR
+$BIN_DIR/e2e.test -ginkgo.v -test.v -ginkgo.no-color --kubectl-path $KUBECTL_PATH --clusterctl-path $CLUSTERCTL_PATH  --working-dir $TEST_WORKING_DIR --dump-path $DUMP_PATH


### PR DESCRIPTION
**What this PR does / why we need it**:
The kubevirt project has a cmd to dump artifacts with the k8s reporter.
This changes creates a similar dump command integrated with the capk
deps, It will dump stuff at JustAfterEach it test fails.

The artifacts are stored by [file-name]:[line-number] like at following run:
https://gcsweb.ci.kubevirt.io/gcs/kubevirt-prow/pr-logs/pull/kubernetes-sigs_cluster-api-provider-kubevirt/156/pull-kubernetes-sigs-cluster-api-provider-kubevirt-e2e/1551839261811019776/artifacts/

```release-note
NONE
```
