### PR TITLE
Avoid reporting not-found errors when patching resources under deletion.

### DIFF
--- a/controllers/kubevirtcluster_controller.go
+++ b/controllers/kubevirtcluster_controller.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
@@ -115,9 +116,11 @@ func (r *KubevirtClusterReconciler) Reconcile(goctx gocontext.Context, req ctrl.
 	// Always attempt to Patch the KubevirtCluster object and status after each reconciliation.
 	defer func() {
 		if err := clusterContext.PatchKubevirtCluster(patchHelper); err != nil {
-			clusterContext.Logger.Error(err, "failed to patch KubevirtCluster")
-			if rerr == nil {
-				rerr = err
+			if !apierrors.IsNotFound(utilerrors.Reduce(err)) {
+				clusterContext.Logger.Error(err, "failed to patch KubevirtCluster")
+				if rerr == nil {
+					rerr = err
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
**What this PR does / why we need it**:

When reconciling for deletion, the KubevirtCluster and KubevirtMachine controllers both attempt to patch, as the last step of the reconciliation, the resource in order to indicate to the user that it is being deleted. It is possible that, by the time these patches are called, the resource is already deleted; which result of the patch failing with a `NotFound` error that is then reported at the error level in the log.

Because this is an expected case, this change silences `NotFound` errors raised by these two final patches. 

**Which issue this PR fixes**:

fixes #152

**Special notes for your reviewer**:

Note that the patch methods return an `k8s.io/apimachinery/pkg/util/errors#Aggregate` error in this case; which will not be recognized by the `apierrors.IsNotFound` method. So, I am extracting the error using the `Reduce` method to extract the aggregated error, if there is only one and the error passed to the method is an aggregate.

Note also that, for the KubevirtCluster controller, the change will also apply when a normal reconciliation happens. I believe that this is acceptable as the existence of the resource has been access before and this change should not obfuscate unexpected failures.

**Release notes**:

```release-note
NONE
```
