### PR TITLE
Copy Kubeadm userdata secret labels to CAPK secret.

### DIFF
--- a/controllers/kubevirtmachine_controller.go
+++ b/controllers/kubevirtmachine_controller.go
@@ -596,6 +596,7 @@ func (r *KubevirtMachineReconciler) reconcileKubevirtBootstrapSecret(ctx *contex
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      s.Name + "-userdata",
 			Namespace: vmNamespace,
+			Labels:    s.Labels,
 		},
 	}
 	ctx.BootstrapDataSecret = newBootstrapDataSecret

--- a/controllers/kubevirtmachine_controller_test.go
+++ b/controllers/kubevirtmachine_controller_test.go
@@ -297,8 +297,9 @@ var _ = Describe("reconcile a kubevirt machine", func() {
 		bootstrapDataSecret := &corev1.Secret{}
 		err = fakeClient.Get(gocontext.Background(), machineBootstrapSecretReferenceKey, bootstrapDataSecret)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(bootstrapDataSecret.Data["userdata"]).To(Equal([]byte("shell-script")))
-		Expect(bootstrapDataSecret.Labels).To(Equal(map[string]string{"hello": "world"}))
+		Expect(bootstrapDataSecret.Data).To(HaveKeyWithValue("userdata", []byte("shell-script")))
+		Expect(bootstrapDataSecret.Labels).To(HaveLen(1))
+		Expect(bootstrapDataSecret.Labels).To(HaveKeyWithValue("hello", "world"))
 	})
 
 	It("should ensure deletion of KubevirtMachine garbage collects everything successfully", func() {
@@ -487,8 +488,9 @@ var _ = Describe("reconcile a kubevirt machine", func() {
 		bootstrapDataSecret := &corev1.Secret{}
 		err = fakeClient.Get(gocontext.Background(), machineBootstrapSecretReferenceKey, bootstrapDataSecret)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(bootstrapDataSecret.Data["userdata"]).To(Equal([]byte("shell-script")))
-		Expect(bootstrapDataSecret.Labels).To(Equal(map[string]string{"hello": "world"}))
+		Expect(bootstrapDataSecret.Data).To(HaveKeyWithValue("userdata", []byte("shell-script")))
+		Expect(bootstrapDataSecret.Labels).To(HaveLen(1))
+		Expect(bootstrapDataSecret.Labels).To(HaveKeyWithValue("hello", "world"))
 	})
 
 	It("should create KubeVirt VM in custom namespace", func() {
@@ -532,8 +534,9 @@ var _ = Describe("reconcile a kubevirt machine", func() {
 		bootstrapDataSecret := &corev1.Secret{}
 		err = fakeClient.Get(gocontext.Background(), machineBootstrapSecretReferenceKey, bootstrapDataSecret)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(bootstrapDataSecret.Data["userdata"]).To(Equal([]byte("shell-script")))
-		Expect(bootstrapDataSecret.Labels).To(Equal(map[string]string{"hello": "world"}))
+		Expect(bootstrapDataSecret.Data).To(HaveKeyWithValue("userdata", []byte("shell-script")))
+		Expect(bootstrapDataSecret.Labels).To(HaveLen(1))
+		Expect(bootstrapDataSecret.Labels).To(HaveKeyWithValue("hello", "world"))
 	})
 
 	It("should detect when VMI is ready and mark KubevirtMachine ready", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

This ensures that the `...-userdata` secret CAPK creates to enhance the cloud-init user data generated by Kubeadm has the same label(s) that the latter.

Currently, this results in these secrets getting the `cluster.x-k8s.io/cluster-name=<cluster-name>` label.

**Which issue this PR fixes**: 

fixes #161

**Release notes**:

```release-note
NONE
```
