### PR TITLE
build and publish multi-arch image manifest

### DIFF
--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
       - name: build image
         shell: bash
         env:
@@ -19,8 +21,8 @@ jobs:
           TAG: ${{ github.ref_name }}
         run: |
           echo $QUAY_TOKEN | docker login -u="capk+capk_robot" quay.io --password-stdin
-          make docker-build
-          make docker-push
+          make docker-build-all
+          make docker-push-all
   build:
     name: Upload Release Asset
     needs: build-and-push-image
@@ -37,7 +39,7 @@ jobs:
       - name: Create infrastructure components
         env:
           REGISTRY: "quay.io/capk"
-          IMAGE_NAME: "capk-manager-amd64"
+          IMAGE_NAME: "capk-manager"
           TAG: ${{ github.ref_name }}
         run: |
           make create-infrastructure-components

--- a/.github/workflows/image_build.yaml
+++ b/.github/workflows/image_build.yaml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
       - name: build image
         shell: bash
         env:
@@ -16,5 +18,5 @@ jobs:
           TAG: "dev-latest"
         run: |
           echo $QUAY_TOKEN | docker login -u="capk+capk_robot" quay.io --password-stdin
-          make docker-build
-          make docker-push
+          make docker-build-all
+          make docker-push-all


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

Build and push multi-arch images + manifest in github actions

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #142 

```
❯ curl -L https://github.com/jbpratt/cluster-api-provider-kubevirt/releases/download/v0.1.2-test-3/infrastructure-components.yaml | kubectl apply -f -
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  630k  100  630k    0     0   131k      0  0:00:04  0:00:04 --:--:--     0
namespace/capk-system created
customresourcedefinition.apiextensions.k8s.io/kubevirtclusters.infrastructure.cluster.x-k8s.io created
customresourcedefinition.apiextensions.k8s.io/kubevirtmachines.infrastructure.cluster.x-k8s.io created
customresourcedefinition.apiextensions.k8s.io/kubevirtmachinetemplates.infrastructure.cluster.x-k8s.io created
serviceaccount/capk-manager created
role.rbac.authorization.k8s.io/capk-leader-election-role created
clusterrole.rbac.authorization.k8s.io/capk-manager-role created
clusterrole.rbac.authorization.k8s.io/capk-proxy-role created
rolebinding.rbac.authorization.k8s.io/capk-leader-election-rolebinding created
clusterrolebinding.rbac.authorization.k8s.io/capk-manager-rolebinding created
clusterrolebinding.rbac.authorization.k8s.io/capk-proxy-rolebinding created
service/capk-controller-manager-metrics-service created
service/capk-webhook-service created
deployment.apps/capk-controller-manager created
certificate.cert-manager.io/capk-serving-cert created
issuer.cert-manager.io/capk-selfsigned-issuer created
validatingwebhookconfiguration.admissionregistration.k8s.io/capk-validating-webhook-configuration created

❯ kubectl get pods -n capk-system
NAME                                       READY   STATUS              RESTARTS   AGE
capk-controller-manager-6856dbb6c6-4bpwm   2/2     Running             0          9s
```

Run the make targets to build and publish the multi-arch images and
manifest, updating the image kustomized into the manager deployment to
be the manifest.

Signed-off-by: jbpratt <jbpratt78@gmail.com>

I did a test release here https://github.com/jbpratt/cluster-api-provider-kubevirt/releases/tag/v0.1.2-test-3

**Special notes for your reviewer**:
:)

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Publish a multi-arch image manifest with amd64, arm64 and arm images
```
