### PR TITLE
dnm: Test ovn multinet + kind

### DIFF
--- a/hack/kind-ovn.sh
+++ b/hack/kind-ovn.sh
@@ -1,0 +1,29 @@
+#!/bin/bash -xe 
+if [ ! -d ovn-kubernetes ]; then 
+    git clone https://github.com/qinqon/ovn-kubernetes -b dnm-kind-and-multi-network
+fi
+pushd ovn-kubernetes
+    pushd go-controller
+    make
+    popd
+
+    pushd dist/images
+    make fedora
+    popd
+
+    pushd contrib
+    export KUBECONFIG=${HOME}/ovn.conf
+    ./kind.sh
+    popd
+popd 
+export KUBEVIRT_PROVIDER=external
+for i in ovn-control-plane ovn-worker ovn-worker2; do 
+    docker exec -t $i bash -c "echo 'fs.inotify.max_user_watches=1048576' >> /etc/sysctl.conf"
+    docker exec -t $i bash -c "echo 'fs.inotify.max_user_instances=512' >> /etc/sysctl.conf"
+    docker exec -i $i bash -c "sysctl -p /etc/sysctl.conf"
+done
+./kubevirtci down
+./kubevirtci up
+./kubevirtci install-capk
+./kubevirtci create-cluster
+./kubevirtci install-calico

--- a/kubevirtci
+++ b/kubevirtci
@@ -5,7 +5,7 @@ set -e
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.23}
 export CAPK_GUEST_K8S_VERSION=${CAPK_GUEST_K8S_VERSION:-v1.22.0}
 export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-2205231118-f12b50e}
-export KUBECONFIG=$(cluster-up/cluster-up/kubeconfig.sh)
+export KUBECONFIG=${KUBECONFIG:-$(cluster-up/cluster-up/kubeconfig.sh)}
 export KUBEVIRT_DEPLOY_PROMETHEUS=false
 export KUBEVIRT_DEPLOY_CDI=false
 export KUBEVIRT_NUM_NODES=${KUBEVIRT_NUM_NODES:-1}
@@ -89,8 +89,9 @@ function kubevirtci::fetch_kubevirtci() {
 }
 
 function kubevirtci::up() {
-	make cluster-up -C cluster-up
-	export KUBECONFIG=$(cluster-up/cluster-up/kubeconfig.sh)
+    if [ "$KUBEVIRT_PROVIDER" != "external" ]; then
+	    make cluster-up -C cluster-up
+    fi
 	echo "installing kubevirt..."
 	${_kubectl} apply -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-operator.yaml
 	curl -L https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-cr.yaml \

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -33,6 +33,22 @@ spec:
     spec:
       type: ClusterIP
 ---
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: ovn-storage
+  namespace: kvcluster
+spec:
+  config: '{
+      "cniVersion": "0.4.0",
+      "name": "ovn-storage",
+      "netAttachDefName": "kvcluster/ovn-storage",
+      "isSecondary": true,
+      "netCIDR": "10.193.0.0/16/26",
+      "mtu": 1500,
+      "type": "ovn-k8s-cni-overlay"
+    }'
+---
 apiVersion: infrastructure.cluster.x-k8s.io/v1alpha1
 kind: KubevirtMachineTemplate
 metadata:
@@ -54,11 +70,18 @@ spec:
                 memory:
                   guest: "4Gi"
                 devices:
+                  interfaces:
+                  - name: ovn
+                    bridge: {}
                   disks:
                     - disk:
                         bus: virtio
                       name: containervolume
               evictionStrategy: External
+              networks:
+              - name: ovn
+                multus:
+                  networkName: ovn-storage
               volumes:
                 - containerDisk:
                     image: "${NODE_VM_IMAGE_TEMPLATE}"
@@ -113,11 +136,18 @@ spec:
                 memory:
                   guest: "4Gi"
                 devices:
+                  interfaces:
+                  - name: ovn
+                    bridge: {}
                   disks:
                     - disk:
                         bus: virtio
                       name: containervolume
               evictionStrategy: External
+              networks:
+              - name: ovn
+                multus:
+                  networkName: ovn-storage
               volumes:
                 - containerDisk:
                     image: "${NODE_VM_IMAGE_TEMPLATE}"


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a DNM PR to test the ovn-kubernetes multinet WIP feature, it starts the the ovn-kubernetes WIP PR over a kind cluster and deploy capk into ti 

**Special notes for your reviewer**:

The calico node pod at tenant on the worker does not reach ready state.

Logs from worker VMI `sudo crictl logs` for calico-node:
```
2022-09-06 13:56:15.104 [INFO][9] startup/startup.go 417: Hit error connecting to datastore - retry error=Get "https://10.95.0.1:443/api/v1/nodes/foo": dial tcp 10.95.0.1:443: connect: connection refused

```

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
