### PR TITLE
tests, artifacts: Fix the version to dl kv dump

### DIFF
--- a/hack/run-e2e.sh
+++ b/hack/run-e2e.sh
@@ -13,7 +13,7 @@ export ARTIFACTS=${ARTIFACTS:-k8s-reporter}
 mkdir -p $ARTIFACTS
 
 if [ ! -f "$DUMP_PATH" ]; then
-    curl -L https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/${version}/testing/dump -o $DUMP_PATH
+    curl -L https://storage.googleapis.com/kubevirt-prow/devel/nightly/release/kubevirt/kubevirt/${DUMP_VERSION}/testing/dump -o $DUMP_PATH
     chmod 755 $DUMP_PATH
 fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The variable used to pass the kubevirt version to the dump URL was wrong, this change fix that.

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
