### PR TITLE
kubevirtci: Refactor fetch mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 cluster-up/
+.kubevirtci/
 hack/tools/bin/
 bin/
 .idea/

--- a/kubevirtci
+++ b/kubevirtci
@@ -5,7 +5,6 @@ set -e
 export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.23}
 export CAPK_GUEST_K8S_VERSION=${CAPK_GUEST_K8S_VERSION:-v1.23.10}
 export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-2205231118-f12b50e}
-export KUBECONFIG=$(cluster-up/cluster-up/kubeconfig.sh)
 export KUBEVIRT_DEPLOY_PROMETHEUS=false
 export KUBEVIRT_DEPLOY_CDI=false
 export KUBEVIRT_NUM_NODES=${KUBEVIRT_NUM_NODES:-1}
@@ -18,6 +17,9 @@ export CALICO_VERSION="v3.21"
 export KUBEVIRT_VERSION="v0.53.0"
 export NODE_VM_IMAGE_TEMPLATE=${NODE_VM_IMAGE_TEMPLATE:-quay.io/capk/ubuntu-2004-container-disk:${CAPK_GUEST_K8S_VERSION}}
 
+KUBEVIRTCI_REPO='https://github.com/kubevirt/kubevirtci.git'
+KUBEVIRTCI_PATH="${PWD}/.kubevirtci/"
+
 _default_bin_path=./hack/tools/bin
 _default_tmp_path=./hack/tools/bin/tmp
 _default_clusterctl_path=./hack/tools/bin/clusterctl
@@ -27,8 +29,8 @@ export CLUSTERCTL_PATH=${CLUSTERCTL_PATH:-${_default_clusterctl_path}}
 export TENANT_CLUSTER_NAME=${TENANT_CLUSTER_NAME:-kvcluster}
 export TENANT_CLUSTER_NAMESPACE=${TENANT_CLUSTER_NAMESPACE:-kvcluster}
 
-_kubectl=cluster-up/cluster-up/kubectl.sh
-_ssh_infra=cluster-up/cluster-up/ssh.sh
+_kubectl=${KUBEVIRTCI_PATH}/cluster-up/kubectl.sh
+_ssh_infra=${KUBEVIRTCI_PATH}/cluster-up/ssh.sh
 
 _action=$1
 shift
@@ -68,12 +70,38 @@ function kubevirtci::usage() {
 }
 
 function kubevirtci::kubeconfig() {
-	cluster-up/cluster-up/kubeconfig.sh
+	${KUBEVIRTCI_PATH}/cluster-up/kubeconfig.sh
 }
 
-function kubevirtci::fetch_kubevirtci() {
-	[[ -d cluster-up ]] || git clone https://github.com/kubevirt/kubevirtci.git cluster-up
-	(cd cluster-up && git checkout main > /dev/null 2>&1 && git pull > /dev/null && git checkout ${KUBEVIRTCI_TAG} > /dev/null 2>&1)
+function kubevirtci::_get_repo() {
+	git --git-dir "${KUBEVIRTCI_PATH}/.git" remote get-url origin
+}
+
+function kubevirtci::_get_tag() {
+	git -C ${KUBEVIRTCI_PATH} describe --tags
+}
+
+function kubevirtci::ensure() {
+	# Remove cloned kubevirtci repository if it does not match the requested one
+	if [ -d ${KUBEVIRTCI_PATH} ]; then
+		if [ $(kubevirtci::_get_repo) != ${KUBEVIRTCI_REPO} -o $(kubevirtci::_get_tag) != ${KUBEVIRTCI_TAG} ]; then
+			rm -rf ${KUBEVIRTCI_PATH}
+		fi
+	fi
+
+	if [ ! -d ${KUBEVIRTCI_PATH} ]; then
+		git clone ${KUBEVIRTCI_REPO} ${KUBEVIRTCI_PATH}
+		(
+			cd ${KUBEVIRTCI_PATH}
+			git checkout ${KUBEVIRTCI_TAG}
+		)
+	fi
+    export KUBECONFIG=$(kubevirtci::kubeconfig)
+	kubevirtci::ensure_tools
+}
+
+
+function kubevirtci::ensure_tools() {
 	mkdir -p ./hack/tools/bin/
 	if [ ! -f "${_default_clusterctl_path}" ]; then
 		echo >&2 "Downloading clusterctl version ${CLUSTERCTL_VERSION}..."
@@ -88,10 +116,10 @@ function kubevirtci::fetch_kubevirtci() {
 }
 
 function kubevirtci::up() {
-	make cluster-up -C cluster-up
-	export KUBECONFIG=$(cluster-up/cluster-up/kubeconfig.sh)
+	"${KUBEVIRTCI_PATH}/cluster-up/up.sh"
+	export KUBECONFIG=$(kubevirtci::kubeconfig)
 	echo "installing kubevirt..."
-	${_kubectl} apply -f https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-operator.yaml
+	${_kubectl} apply -f "https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-operator.yaml"
 	curl -L https://github.com/kubevirt/kubevirt/releases/download/${KUBEVIRT_VERSION}/kubevirt-cr.yaml \
 	   | sed -e "s|\( \+\)\(featureGates:\).*$|\1\2\n\1- LiveMigration|" \
 	   | ${_kubectl} apply -f -
@@ -108,11 +136,11 @@ EOF
 }
 
 function kubevirtci::down() {
-	make cluster-down -C cluster-up
+	"${KUBEVIRTCI_PATH}/cluster-up/down.sh"
 }
 
 function kubevirtci::build() {
-	export REGISTRY="127.0.0.1:$(cluster-up/cluster-up/cli.sh ports registry)"
+	export REGISTRY="127.0.0.1:$(${KUBEVIRTCI_PATH}/cluster-up/cli.sh ports registry)"
 	make docker-build
 	make docker-push
 }
@@ -336,7 +364,7 @@ function kubevirtci::vm_matches {
     ${_kubectl} get vm -n ${TENANT_CLUSTER_NAMESPACE} --no-headers -o custom-columns=":metadata.name" | grep -q $vm_name
 }
 
-kubevirtci::fetch_kubevirtci
+kubevirtci::ensure
 
 case ${_action} in
 "up")


### PR DESCRIPTION
**What this PR does / why we need it**:
Everytime kubevirtci is call a fetch is run this is totally unnecesary and somtimes it fails, this change refactor the fetch to do it when necessary and also move the kubevirtci cloned path to .kubevirtci.

```release-note
NONE
```
