### PR TITLE
Remove the IMAGE_REPO env var from all the temlates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.1-experimental
+# syntax=docker/dockerfile:1.4
 
 # Copyright 2021 The Kubernetes Authors.
 #

--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ modules: ## Runs go mod to ensure modules are up to date.
 
 .PHONY: docker-pull-prerequisites
 docker-pull-prerequisites:
-	docker pull docker.io/docker/dockerfile:1.1-experimental
+	docker pull docker.io/docker/dockerfile:1.4
 	docker pull docker.io/library/golang:1.18.2
 	docker pull gcr.io/distroless/static:latest
 

--- a/hack/functest.sh
+++ b/hack/functest.sh
@@ -13,7 +13,6 @@ echo "Building and installing capk manager container"
 
 echo "Running e2e test suite"
 export KUBECONFIG=$(./kubevirtci kubeconfig)
-export IMAGE_REPO=k8s.gcr.io
 export TENANT_CLUSTER_KUBERNETES_VERSION="v1.23.10"
 export NODE_VM_IMAGE_TEMPLATE=quay.io/capk/ubuntu-2004-container-disk:${TENANT_CLUSTER_KUBERNETES_VERSION}
 export CRI_PATH=/var/run/containerd/containerd.sock

--- a/kubevirtci
+++ b/kubevirtci
@@ -12,7 +12,7 @@ export KUBEVIRT_MEMORY_SIZE=${KUBEVIRT_MEMORY_SIZE:-15360M}
 export KUBEVIRT_DEPLOY_CDI="true"
 export METALLB_VERSION="v0.12.1"
 export CAPK_RELEASE_VERSION="v0.1.0-rc.0"
-export CLUSTERCTL_VERSION="v1.0.0"
+export CLUSTERCTL_VERSION="v1.2.4"
 export CALICO_VERSION="v3.21"
 export KUBEVIRT_VERSION="v0.53.0"
 export NODE_VM_IMAGE_TEMPLATE=${NODE_VM_IMAGE_TEMPLATE:-quay.io/capk/ubuntu-2004-container-disk:${TENANT_CLUSTER_KUBERNETES_VERSION}}
@@ -188,7 +188,6 @@ function kubevirtci::destroy_cluster() {
 
 
 function kubevirtci::create_cluster() {
-	export IMAGE_REPO=k8s.gcr.io
 	export CRI_PATH="/var/run/containerd/containerd.sock"
 	template=templates/cluster-template-kccm.yaml
 
@@ -212,7 +211,6 @@ function kubevirtci::create_cluster() {
 
 
 function kubevirtci::create_external_cluster() {
-	export IMAGE_REPO=k8s.gcr.io
 	export CRI_PATH="/var/run/containerd/containerd.sock"
 
 	${_kubectl} delete secret external-infra-kubeconfig -n capk-system --ignore-not-found

--- a/templates/cluster-template-ext-infra.yaml
+++ b/templates/cluster-template-ext-infra.yaml
@@ -79,7 +79,6 @@ spec:
       namespace: "${NAMESPACE}"
   kubeadmConfigSpec:
     clusterConfiguration:
-      imageRepository: ${IMAGE_REPO}
       networking:
         dnsDomain: "${CLUSTER_NAME}.${NAMESPACE}.local"
         podSubnet: 10.243.0.0/16

--- a/templates/cluster-template-kccm.yaml
+++ b/templates/cluster-template-kccm.yaml
@@ -79,7 +79,6 @@ spec:
       namespace: "${NAMESPACE}"
   kubeadmConfigSpec:
     clusterConfiguration:
-      imageRepository: ${IMAGE_REPO}
       networking:
         dnsDomain: "${CLUSTER_NAME}.${NAMESPACE}.local"
         podSubnet: 10.243.0.0/16

--- a/templates/cluster-template-lb.yaml
+++ b/templates/cluster-template-lb.yaml
@@ -79,7 +79,6 @@ spec:
       namespace: "${NAMESPACE}"
   kubeadmConfigSpec:
     clusterConfiguration:
-      imageRepository: ${IMAGE_REPO}
       networking:
         dnsDomain: "${CLUSTER_NAME}.${NAMESPACE}.local"
         podSubnet: 10.243.0.0/16

--- a/templates/cluster-template-persistent-storage-kccm.yaml
+++ b/templates/cluster-template-persistent-storage-kccm.yaml
@@ -89,7 +89,6 @@ spec:
       namespace: "${NAMESPACE}"
   kubeadmConfigSpec:
     clusterConfiguration:
-      imageRepository: ${IMAGE_REPO}
       networking:
         dnsDomain: "${CLUSTER_NAME}.${NAMESPACE}.local"
         podSubnet: 10.243.0.0/16

--- a/templates/cluster-template-persistent-storage.yaml
+++ b/templates/cluster-template-persistent-storage.yaml
@@ -89,7 +89,6 @@ spec:
       namespace: "${NAMESPACE}"
   kubeadmConfigSpec:
     clusterConfiguration:
-      imageRepository: ${IMAGE_REPO}
       networking:
         dnsDomain: "${CLUSTER_NAME}.${NAMESPACE}.local"
         podSubnet: 10.243.0.0/16

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -79,7 +79,6 @@ spec:
       namespace: "${NAMESPACE}"
   kubeadmConfigSpec:
     clusterConfiguration:
-      imageRepository: ${IMAGE_REPO}
       networking:
         dnsDomain: "${CLUSTER_NAME}.${NAMESPACE}.local"
         podSubnet: 10.243.0.0/16


### PR DESCRIPTION
cluster-api project wants to stop using the k8s.gcr.io repository, as it's too expensive. After checking in other cluster API project, it seems that this value is no longer in the template.

This PR removes all the usage in IMAGE_REPO variable; for that, the PR also upgrade the clusterctl in the kubevirtci script, to v1.2.4

Signed-off-by: Nahshon Unna-Tsameret <nunnatsa@redhat.com>

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
None
```
