### PR TITLE
Allow podman to push images to insecure kubevirtci registry

### DIFF
--- a/kubevirtci
+++ b/kubevirtci
@@ -141,6 +141,13 @@ function kubevirtci::down() {
 
 function kubevirtci::build() {
 	export REGISTRY="127.0.0.1:$(${KUBEVIRTCI_PATH}/cluster-up/cli.sh ports registry)"
+	if curl --unix-socket "/run/podman/podman.sock" http://d/v3.0.0/libpod/info >/dev/null 2>&1; then
+		cat <<EOF >> /etc/containers/registries.conf
+[[registry]]
+location = "$REGISTRY"
+insecure = true
+EOF
+	fi
 	make docker-build
 	make docker-push
 }


### PR DESCRIPTION
Signed-off-by: Brian Carey <bcarey@redhat.com>

**What this PR does / why we need it**:
These changes are required to run the e2e test job under podman. Kubevirt CI has been working on moving all jobs to run under podman and the old docker in docker setup will no longer be supported. 

Add the insecure kubevirtci registry to registries.conf when using podman to push images to the registry. Currently this fails in CI as podman is unable to push to insecure registries by default. 

https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubernetes-sigs_cluster-api-provider-kubevirt/207/pull-kubernetes-sigs-cluster-api-provider-kubevirt-e2e/1592063138562314240#1:build-log.txt%3A510

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
