### PR TITLE
Use nocloud when specified

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-logr/logr v1.2.3
 	github.com/golang/glog v1.0.0
 	github.com/golang/mock v1.6.0
+	github.com/imdario/mergo v0.3.12
 	github.com/onsi/ginkgo/v2 v2.1.4
 	github.com/onsi/gomega v1.19.0
 	github.com/pkg/errors v0.9.1
@@ -61,7 +62,6 @@ require (
 	github.com/googleapis/gnostic v0.5.5 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/gregjones/httpcache v0.0.0-20181110185634-c63ab54fda8f // indirect
-	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/pkg/kubevirt/machine.go
+++ b/pkg/kubevirt/machine.go
@@ -155,7 +155,10 @@ func (m *Machine) Exists() bool {
 func (m *Machine) Create(ctx gocontext.Context) error {
 	m.machineContext.Logger.Info(fmt.Sprintf("Creating VM with role '%s'...", nodeRole(m.machineContext)))
 
-	virtualMachine := newVirtualMachineFromKubevirtMachine(m.machineContext, m.namespace)
+	virtualMachine, err := newVirtualMachineFromKubevirtMachine(m.machineContext, m.namespace)
+	if err != nil {
+		return err
+	}
 
 	mutateFn := func() (err error) {
 		if virtualMachine.Labels == nil {

--- a/pkg/kubevirt/machine_test.go
+++ b/pkg/kubevirt/machine_test.go
@@ -310,7 +310,7 @@ var _ = Describe("util functions", func() {
 		machineContext.KubevirtMachine.Spec.VirtualMachineTemplate.Spec.Template.Spec.Volumes = volumes
 
 		newVM, err := newVirtualMachineFromKubevirtMachine(machineContext, "default")
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 
 		Expect(newVM.Spec.DataVolumeTemplates[0].ObjectMeta.Name).To(Equal(kubevirtMachineName + "-dv1"))
 		Expect(newVM.Spec.Template.Spec.Volumes[0].VolumeSource.DataVolume.Name).To(Equal(kubevirtMachineName + "-dv1"))
@@ -455,7 +455,7 @@ var _ = Describe("util functions", func() {
 		machineContext.KubevirtMachine.Spec.VirtualMachineTemplate.Spec.Template.Spec.Volumes = volumes
 
 		newVM, err := newVirtualMachineFromKubevirtMachine(machineContext, "default")
-		Expect(err).To(BeNil())
+		Expect(err).ToNot(HaveOccurred())
 
 		Expect(newVM.Spec.DataVolumeTemplates[0].ObjectMeta.Name).To(Equal(kubevirtMachineName + "-dv1"))
 		Expect(newVM.Spec.Template.Spec.Volumes[0].VolumeSource.DataVolume.Name).To(Equal(kubevirtMachineName + "-dv1"))

--- a/pkg/kubevirt/machine_test.go
+++ b/pkg/kubevirt/machine_test.go
@@ -309,7 +309,8 @@ var _ = Describe("util functions", func() {
 		machineContext.KubevirtMachine.Spec.VirtualMachineTemplate.Spec.DataVolumeTemplates = dataVolumeTemplates
 		machineContext.KubevirtMachine.Spec.VirtualMachineTemplate.Spec.Template.Spec.Volumes = volumes
 
-		newVM := newVirtualMachineFromKubevirtMachine(machineContext, "default")
+		newVM, err := newVirtualMachineFromKubevirtMachine(machineContext, "default")
+		Expect(err).To(BeNil())
 
 		Expect(newVM.Spec.DataVolumeTemplates[0].ObjectMeta.Name).To(Equal(kubevirtMachineName + "-dv1"))
 		Expect(newVM.Spec.Template.Spec.Volumes[0].VolumeSource.DataVolume.Name).To(Equal(kubevirtMachineName + "-dv1"))
@@ -453,7 +454,8 @@ var _ = Describe("util functions", func() {
 		machineContext.KubevirtMachine.Spec.VirtualMachineTemplate.Spec.DataVolumeTemplates = dataVolumeTemplates
 		machineContext.KubevirtMachine.Spec.VirtualMachineTemplate.Spec.Template.Spec.Volumes = volumes
 
-		newVM := newVirtualMachineFromKubevirtMachine(machineContext, "default")
+		newVM, err := newVirtualMachineFromKubevirtMachine(machineContext, "default")
+		Expect(err).To(BeNil())
 
 		Expect(newVM.Spec.DataVolumeTemplates[0].ObjectMeta.Name).To(Equal(kubevirtMachineName + "-dv1"))
 		Expect(newVM.Spec.Template.Spec.Volumes[0].VolumeSource.DataVolume.Name).To(Equal(kubevirtMachineName + "-dv1"))

--- a/pkg/kubevirt/utils.go
+++ b/pkg/kubevirt/utils.go
@@ -222,7 +222,7 @@ func detectCloudInitVolumeType(vmi *kubevirtv1.VirtualMachineInstanceTemplateSpe
 			return cloudInitNoCloud, i
 		}
 	}
-	return cloudInitConfigDrive, 0
+	return cloudInitConfigDrive, -1
 }
 
 func detectCloudInitDisk(vmi *kubevirtv1.VirtualMachineInstanceTemplateSpec) (foundCloudInitDisk bool) {

--- a/pkg/kubevirt/utils.go
+++ b/pkg/kubevirt/utils.go
@@ -148,7 +148,10 @@ func buildVirtualMachineInstanceTemplate(ctx *context.MachineContext) *kubevirtv
 	cloudInitDisk := cloudinitDisk(template, cloudInitType)
 	switch cloudInitType {
 	case "CloudInitNoCloud":
-		mergo.Merge(&template.Spec.Volumes[index], cloudInitVolume)
+		err := mergo.Merge(&template.Spec.Volumes[index], cloudInitVolume)
+		if err != nil {
+			panic(err)
+		}
 		break
 	case "CloudInitConfigDrive":
 		template.Spec.Volumes = append(template.Spec.Volumes, cloudInitVolume)

--- a/pkg/kubevirt/utils.go
+++ b/pkg/kubevirt/utils.go
@@ -156,7 +156,7 @@ func buildVirtualMachineInstanceTemplate(ctx *context.MachineContext) (*kubevirt
 	case "CloudInitConfigDrive":
 		template.Spec.Volumes = append(template.Spec.Volumes, cloudInitVolume)
 	}
-	if found, _ := detectCloudInitDisk(template); !found {
+	if !detectCloudInitDisk(template) {
 		template.Spec.Domain.Devices.Disks = append(template.Spec.Domain.Devices.Disks, cloudInitDisk)
 	}
 

--- a/pkg/kubevirt/utils.go
+++ b/pkg/kubevirt/utils.go
@@ -218,12 +218,11 @@ func detectCloudInitVolumeType(vmi *kubevirtv1.VirtualMachineInstanceTemplateSpe
 	return "CloudInitConfigDrive", 0
 }
 
-func detectCloudInitDisk(vmi *kubevirtv1.VirtualMachineInstanceTemplateSpec) (found bool, index int) {
-	for i, v := range vmi.Spec.Domain.Devices.Disks {
+func detectCloudInitDisk(vmi *kubevirtv1.VirtualMachineInstanceTemplateSpec) (foundCloudInitDisk bool) {
+	for _, v := range vmi.Spec.Domain.Devices.Disks {
 		if v.Disk != nil && v.Name == cloudInitVolumeName {
-			found, index = true, i
-			break
+			return true
 		}
 	}
-	return found, index
+	return false
 }

--- a/pkg/kubevirt/utils.go
+++ b/pkg/kubevirt/utils.go
@@ -209,15 +209,13 @@ func cloudinitDisk(vmi *kubevirtv1.VirtualMachineInstanceTemplateSpec, preferred
 	}
 }
 
-func detectCloudInitVolumeType(vmi *kubevirtv1.VirtualMachineInstanceTemplateSpec) (preferredType string, index int) {
-	preferredType = "CloudInitConfigDrive"
+func detectCloudInitVolumeType(vmi *kubevirtv1.VirtualMachineInstanceTemplateSpec) (preferredCloudInitVolumeType string, existingCloudInitVolumeIndex int) {
 	for i, v := range vmi.Spec.Volumes {
 		if v.CloudInitNoCloud != nil && v.Name == cloudInitVolumeName {
-			preferredType, index = "CloudInitNoCloud", i
-			break
+			return "CloudInitNoCloud", i
 		}
 	}
-	return preferredType, index
+	return "CloudInitConfigDrive", 0
 }
 
 func detectCloudInitDisk(vmi *kubevirtv1.VirtualMachineInstanceTemplateSpec) (found bool, index int) {

--- a/pkg/kubevirt/utils.go
+++ b/pkg/kubevirt/utils.go
@@ -152,10 +152,8 @@ func buildVirtualMachineInstanceTemplate(ctx *context.MachineContext) *kubevirtv
 		if err != nil {
 			panic(err)
 		}
-		break
 	case "CloudInitConfigDrive":
 		template.Spec.Volumes = append(template.Spec.Volumes, cloudInitVolume)
-		break
 	}
 	if found, _ := detectCloudInitDisk(template); !found {
 		template.Spec.Domain.Devices.Disks = append(template.Spec.Domain.Devices.Disks, cloudInitDisk)

--- a/pkg/kubevirt/utils.go
+++ b/pkg/kubevirt/utils.go
@@ -142,7 +142,7 @@ func buildVirtualMachineInstanceTemplate(ctx *context.MachineContext) *kubevirtv
 
 	template.Spec = *ctx.KubevirtMachine.Spec.VirtualMachineTemplate.Spec.Template.Spec.DeepCopy()
 
-	cloudInitType, index := noCloudVolume(template)
+	cloudInitType, index := detectCloudInitVolumeType(template)
 	cloudInitVolume := cloudinitVolume(template, ctx, cloudInitType)
 	cloudInitDisk := cloudinitDisk(template, cloudInitType)
 	if cloudInitType == "CloudInitNoCloud" {
@@ -217,7 +217,7 @@ func cloudinitDisk(vmi *kubevirtv1.VirtualMachineInstanceTemplateSpec, preferred
 	}
 }
 
-func noCloudVolume(vmi *kubevirtv1.VirtualMachineInstanceTemplateSpec) (preferredType string, index int) {
+func detectCloudInitVolumeType(vmi *kubevirtv1.VirtualMachineInstanceTemplateSpec) (preferredType string, index int) {
 	preferredType = "CloudInitConfigDrive"
 	for i, v := range vmi.Spec.Volumes {
 		if v.CloudInitNoCloud != nil && v.Name == "cloudinitvolume" {

--- a/pkg/kubevirt/utils.go
+++ b/pkg/kubevirt/utils.go
@@ -19,6 +19,7 @@ package kubevirt
 import (
 	"fmt"
 
+	"github.com/imdario/mergo"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubevirtv1 "kubevirt.io/api/core/v1"
@@ -146,7 +147,7 @@ func buildVirtualMachineInstanceTemplate(ctx *context.MachineContext) *kubevirtv
 	cloudInitVolume := cloudinitVolume(template, ctx, cloudInitType)
 	cloudInitDisk := cloudinitDisk(template, cloudInitType)
 	if cloudInitType == "CloudInitNoCloud" {
-		template.Spec.Volumes[index] = cloudInitVolume
+		mergo.Merge(&template.Spec.Volumes[index], cloudInitVolume)
 	} else {
 		template.Spec.Volumes = append(template.Spec.Volumes, cloudInitVolume)
 	}

--- a/pkg/kubevirt/utils.go
+++ b/pkg/kubevirt/utils.go
@@ -218,11 +218,12 @@ func cloudinitDisk(vmi *kubevirtv1.VirtualMachineInstanceTemplateSpec, preferred
 }
 
 func noCloudVolume(vmi *kubevirtv1.VirtualMachineInstanceTemplateSpec) (preferredType string, index int) {
+	preferredType = "CloudInitConfigDrive"
 	for i, v := range vmi.Spec.Volumes {
 		if v.CloudInitNoCloud != nil && v.Name == "cloudinitvolume" {
 			preferredType, index = "CloudInitNoCloud", i
 			break
 		}
 	}
-	return "CloudInitConfigDrive", index
+	return preferredType, index
 }

--- a/pkg/kubevirt/utils.go
+++ b/pkg/kubevirt/utils.go
@@ -159,7 +159,10 @@ func buildVirtualMachineInstanceTemplate(ctx *context.MachineContext) (*kubevirt
 	switch cloudInitType {
 	case cloudInitNoCloud:
 		err := mergo.Merge(&template.Spec.Volumes[index], cloudInitVolume)
-		return nil, err
+		if err != nil {
+			return nil, err
+		}
+		return template, nil
 	case cloudInitConfigDrive:
 		template.Spec.Volumes = append(template.Spec.Volumes, cloudInitVolume)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Allows for _CloudInitNoCloud_ volume type to be used and filled in when a volume is specified with the given type and the name "_cloudinitvolume_" and doesn't insert a _CloudInitConfigDrive_ volume and disk.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #200 

**Special notes for your reviewer**:

**Release notes**:

```release-note
NONE
```
