### PR TITLE
templates: Activate net multiqueue

### DIFF
--- a/templates/cluster-template-ext-infra.yaml
+++ b/templates/cluster-template-ext-infra.yaml
@@ -54,6 +54,7 @@ spec:
                 memory:
                   guest: "4Gi"
                 devices:
+                  networkInterfaceMultiqueue: true
                   disks:
                     - disk:
                         bus: virtio
@@ -110,6 +111,7 @@ spec:
                 memory:
                   guest: "4Gi"
                 devices:
+                  networkInterfaceMultiqueue: true
                   disks:
                     - disk:
                         bus: virtio

--- a/templates/cluster-template-kccm.yaml
+++ b/templates/cluster-template-kccm.yaml
@@ -54,6 +54,7 @@ spec:
                 memory:
                   guest: "4Gi"
                 devices:
+                  networkInterfaceMultiqueue: true
                   disks:
                     - disk:
                         bus: virtio
@@ -112,6 +113,7 @@ spec:
                 memory:
                   guest: "4Gi"
                 devices:
+                  networkInterfaceMultiqueue: true
                   disks:
                     - disk:
                         bus: virtio

--- a/templates/cluster-template-lb-kccm.yaml
+++ b/templates/cluster-template-lb-kccm.yaml
@@ -54,6 +54,7 @@ spec:
                 memory:
                   guest: "4Gi"
                 devices:
+                  networkInterfaceMultiqueue: true
                   disks:
                     - disk:
                         bus: virtio
@@ -112,6 +113,7 @@ spec:
                 memory:
                   guest: "4Gi"
                 devices:
+                  networkInterfaceMultiqueue: true
                   disks:
                     - disk:
                         bus: virtio

--- a/templates/cluster-template-lb.yaml
+++ b/templates/cluster-template-lb.yaml
@@ -54,6 +54,7 @@ spec:
                 memory:
                   guest: "4Gi"
                 devices:
+                  networkInterfaceMultiqueue: true
                   disks:
                     - disk:
                         bus: virtio
@@ -112,6 +113,7 @@ spec:
                 memory:
                   guest: "4Gi"
                 devices:
+                  networkInterfaceMultiqueue: true
                   disks:
                     - disk:
                         bus: virtio

--- a/templates/cluster-template-persistent-storage-kccm.yaml
+++ b/templates/cluster-template-persistent-storage-kccm.yaml
@@ -64,6 +64,7 @@ spec:
                 memory:
                   guest: "4Gi"
                 devices:
+                  networkInterfaceMultiqueue: true
                   disks:
                     - disk:
                         bus: virtio
@@ -136,6 +137,7 @@ spec:
                 memory:
                   guest: "4Gi"
                 devices:
+                  networkInterfaceMultiqueue: true
                   disks:
                     - disk:
                         bus: virtio

--- a/templates/cluster-template-persistent-storage.yaml
+++ b/templates/cluster-template-persistent-storage.yaml
@@ -64,6 +64,7 @@ spec:
                 memory:
                   guest: "4Gi"
                 devices:
+                  networkInterfaceMultiqueue: true
                   disks:
                     - disk:
                         bus: virtio
@@ -136,6 +137,7 @@ spec:
                 memory:
                   guest: "4Gi"
                 devices:
+                  networkInterfaceMultiqueue: true
                   disks:
                     - disk:
                         bus: virtio

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -54,6 +54,7 @@ spec:
                 memory:
                   guest: "4Gi"
                 devices:
+                  networkInterfaceMultiqueue: true
                   disks:
                     - disk:
                         bus: virtio
@@ -112,6 +113,7 @@ spec:
                 memory:
                   guest: "4Gi"
                 devices:
+                  networkInterfaceMultiqueue: true
                   disks:
                     - disk:
                         bus: virtio


### PR DESCRIPTION
**What this PR does / why we need it**:
This change the templates VM to be with to improve performance by using net multiqueue [1] .

[1] https://www.linux-kvm.org/page/Multiqueue#Multiqueue_virtio-net

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Activate network multiqueue at cluster templates.
```
