### PR TITLE
Replace deprecated k8s registry references

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ endif
 CONTROLLER_GEN := $(abspath $(TOOLS_BIN_DIR)/controller-gen)
 CONVERSION_GEN := $(abspath $(TOOLS_BIN_DIR)/conversion-gen)
 GOTESTSUM := $(abspath $(TOOLS_BIN_DIR)/gotestsum)
-KUSTOMIZE_IMAGE = k8s.gcr.io/kustomize/kustomize:v3.8.7
+KUSTOMIZE_IMAGE = registry.k8s.io/kustomize/kustomize:v3.8.7
 KUSTOMIZE ?= docker run $(KUSTOMIZE_IMAGE)
 
 # Define Docker related variables. Releases should modify and double check these vars.


### PR DESCRIPTION
**What this PR does / why we need it**:
Problem: Previously all of Kubernetes' image hosting has been out of gcr.io. There were significant egress costs associated with this when images were pulled from entities outside gcp. Refer to https://github.com/kubernetes/k8s.io/wiki/New-Registry-url-for-Kubernetes-(registry.k8s.io)

Solution: As highlighted at KubeCon NA 2022 k8s infra SIG update, the replacement for k8s.gcr.io which is registry.k8s.io is now ready for mainstream use and the old k8s.gcr.io has been formally deprecated and projects are requested to migrate off it. This commit migrates remaining references for kubernetes-sigs/cluster-api-provider-kubevirt to registry.k8s.io.

**Special notes for your reviewer**:
I have verified that `registry.k8s.io/kustomize/kustomize:v3.8.7` exists / can be pulled.

**Release notes**:
None