### PR TITLE
Update to golang 1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 
 # Build the manager binary
 # Run this with docker build --build-arg builder_image=<golang:x.y.z>
-ARG builder_image=golang:1.18.2
+ARG builder_image=golang:1.20.6
 FROM ${builder_image} as builder
 WORKDIR /workspace
 

--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ modules: ## Runs go mod to ensure modules are up to date.
 .PHONY: docker-pull-prerequisites
 docker-pull-prerequisites:
 	docker pull docker.io/docker/dockerfile:1.4
-	docker pull docker.io/library/golang:1.18.2
+	docker pull docker.io/library/golang:1.20.6
 	docker pull gcr.io/distroless/static:latest
 
 .PHONY: docker-build


### PR DESCRIPTION
updates to use golang 1.20.6, the latest stable golang release