### PR TITLE
fix(api): default value for KubeVirtCluster.status.ready field

### DIFF
--- a/api/v1alpha1/kubevirtcluster_types.go
+++ b/api/v1alpha1/kubevirtcluster_types.go
@@ -69,6 +69,7 @@ type KubevirtClusterSpec struct {
 // KubevirtClusterStatus defines the observed state of KubevirtCluster.
 type KubevirtClusterStatus struct {
 	// Ready denotes that the infrastructure is ready.
+	// +kubebuilder:default:=false
 	Ready bool `json:"ready"`
 
 	// FailureDomains don't mean much in CAPD since it's all local, but we can see how the rest of cluster API

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_kubevirtclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_kubevirtclusters.yaml
@@ -236,6 +236,7 @@ spec:
                   if we populate it.
                 type: object
               ready:
+                default: false
                 description: Ready denotes that the infrastructure is ready.
                 type: boolean
             required:


### PR DESCRIPTION
**What this PR does / why we need it**:

It sets a default value for the `KubeVirtCluster.status.ready` field, suppressing the annoying values when updating for the first time `KubeVirtCluster`.

**Which issue this PR fixes**:
fixes #252 

**Special notes for your reviewer**:

Although this changes the specification, thus requiring a minor bump, the API change is absolutely minimal and could be considered a patch one.

**Release notes**:

```release-note
NONE
```
