### PR TITLE
fix: api reader for CCM clean-up to avoid cache lazy loading

### DIFF
--- a/main.go
+++ b/main.go
@@ -170,6 +170,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 
 	if err := (&controllers.KubevirtClusterReconciler{
 		Client:       mgr.GetClient(),
+		APIReader:    mgr.GetAPIReader(),
 		InfraCluster: infracluster.New(mgr.GetClient(), noCachedClient),
 		Log:          ctrl.Log.WithName("controllers").WithName("KubevirtCluster"),
 	}).SetupWithManager(mgr); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Cache lazy loading is disabled when the API Reader client is getting or listing objects, as the opposite with the manager client.

**Which issue this PR fixes**:

fixes #254

**Special notes for your reviewer**:

**Release notes**:

```release-note
NONE
```
