### PR TITLE
chore(golangci-lint): v1.54.2 pinning and config file

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,8 +52,9 @@ jobs:
         go-version-file: go.mod
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3
-      with: # TODO: remove this when the deprecated function will be removed (issue #85)
-        args: --exclude SA1019 --timeout=5m -E ginkgolinter
+      with:
+        args: --timeout=5m -v
+        version: v1.54.2
 
   check-gen:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,22 @@
+linters-settings:
+  ginkgolinter:
+    forbid-focus-container: true
+
+linters:
+  enable:
+    - deadcode
+    - errcheck
+    - ginkgolinter
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unused
+    - varcheck
+  disable: []
+
+issues:
+  exclude:
+    - SA1019 # todo remove the exclude parameter when issue #85 is resolved

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,16 @@ all: test manager
 help:  ## Display this help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
+# go-install-tool will 'go install' any package $2 and install it to $1.
+PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
+define go-install-tool
+@[ -f $(1) ] || { \
+set -e ;\
+echo "Installing $(2)" ;\
+GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
+}
+endef
+
 ## --------------------------------------
 ## Testing
 ## --------------------------------------
@@ -205,7 +215,7 @@ modules: ## Runs go mod to ensure modules are up to date.
 .PHONY: docker-pull-prerequisites
 docker-pull-prerequisites:
 	docker pull docker.io/docker/dockerfile:1.4
-	docker pull docker.io/library/golang:1.20
+	docker pull docker.io/library/golang:1.20.2
 	docker pull gcr.io/distroless/static:latest
 
 .PHONY: docker-build
@@ -329,11 +339,13 @@ goimports:
 	go install golang.org/x/tools/cmd/goimports@latest
 	goimports -w -local="sigs.k8s.io/cluster-api-provider-kubevirt"  $(shell find . -type f -name '*.go' ! -path "*/vendor/*" ! -path "./_kubevirtci/*" ! -path "*zz_generated*" )
 
+GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
+golangci-lint: ## Download golangci-lint locally if necessary.
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@v1.54.2)
+
 .PHONY: linter
-linter:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-	# todo remove the exclude parameter when issue #85 is resolved
-	golangci-lint run --timeout=5m -E ginkgolinter --exclude SA1019
+linter: golangci-lint
+	$(GOLANGCI_LINT) run --timeout=5m -v
 
 .PHONY: sanity
 sanity: linter goimports test


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, there's no version pinning for the `golangci-lint` utility used, I had to manually retrieve it.

Rather, having it declared, makes it easy for contributors to linting the code.

A local binary will be stored in the `./bin` folder to avoid collision with global installed Go modules.

**Which issue this PR fixes**: 

Untracked

**Special notes for your reviewer**:

**Release notes**:
```release-note
NONE
```
