### PR TITLE
Fix "should succeed with the kubevirt cluster being deleted" unit test

### DIFF
--- a/controllers/kubevirtcluster_controller_test.go
+++ b/controllers/kubevirtcluster_controller_test.go
@@ -46,6 +46,7 @@ var _ = Describe("Reconcile", func() {
 		kubevirtClusterReconciler = controllers.KubevirtClusterReconciler{
 			Client:       fakeClient,
 			InfraCluster: infraClusterMock,
+			APIReader:    fakeClient,
 			Log:          testLogger,
 		}
 	}

--- a/hack/kccm-flavor-gen.sh
+++ b/hack/kccm-flavor-gen.sh
@@ -5,6 +5,12 @@ set -x -e -o pipefail
 kccm_template=/tmp/kccm.yaml
 
 kubectl kustomize config/kccm > $kccm_template
+
+
+sed -i \
+    -E "s|(namespace: )kvcluster|\1\${NAMESPACE}|g;s|(^.*cluster-name=)kvcluster|\1\${CLUSTER_NAME}|g" \
+    ${kccm_template}
+
 for cluster_template in $(find templates/ -type f ! -name "*kccm*" -and ! -name "*ext*" -and ! -name "OWNERS"); do
     cluster_kccm_template=${cluster_template%%.*}-kccm.yaml
     cp -f $cluster_template ${cluster_kccm_template}


### PR DESCRIPTION
## What this PR does / why we need it

This unit test is broken. This PR fixes it by populating the `KubevirtClusterReconciler.APIReader` field in unit-test, for mocking.

In addition, this PR also fixes the `hack/kccm-flavor-gen.sh` script so it will
replace the hard coded names with the right variables.

## Which issue this PR fixes
fixes #258 

**Release notes**:
```release-note
None
```
