### PR TITLE
kccm: Bump to v0.5.1

### DIFF
--- a/config/kccm/kustomization.yaml
+++ b/config/kccm/kustomization.yaml
@@ -1,4 +1,14 @@
 namespace: ${NAMESPACE}
+patches:
+- patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: --cluster-name="${CLUSTER_NAME}"
+    - op: replace
+      path: /spec/template/spec/containers/0/image
+      value: quay.io/kubevirt/kubevirt-cloud-controller-manager:v0.5.1
+  target:
+    kind: Deployment
 patchesJson6902:
 - patch: |
     - op: replace
@@ -12,8 +22,9 @@ patchesJson6902:
     version: v1
     kind: Deployment
     name: kubevirt-cloud-controller-manager
+
 bases:
-- https://github.com/kubevirt/cloud-provider-kubevirt/config/isolated?ref=v0.3.2
+- https://github.com/kubevirt/cloud-provider-kubevirt/config/isolated?ref=v0.5.1
 commonLabels:
   cluster.x-k8s.io/cluster-name: "${CLUSTER_NAME}"
   capk.cluster.x-k8s.io/template-kind: "extra-resource"

--- a/templates/cluster-template-kccm.yaml
+++ b/templates/cluster-template-kccm.yaml
@@ -237,7 +237,8 @@ apiVersion: v1
 data:
   cloud-config: |
     loadBalancer:
-      creationPollInterval: 30
+      creationPollInterval: 5
+      creationPollTimeout: 60
     namespace: ${NAMESPACE}
     instancesV2:
       enabled: true
@@ -278,11 +279,11 @@ spec:
         - --cloud-provider=kubevirt
         - --cloud-config=/etc/cloud/cloud-config
         - --kubeconfig=/etc/kubernetes/kubeconfig/value
-        - --cluster-name=${CLUSTER_NAME}
         - --authentication-skip-lookup=true
+        - --cluster-name="${CLUSTER_NAME}"
         command:
         - /bin/kubevirt-cloud-controller-manager
-        image: quay.io/kubevirt/kubevirt-cloud-controller-manager:main
+        image: quay.io/kubevirt/kubevirt-cloud-controller-manager:v0.5.1
         imagePullPolicy: Always
         name: kubevirt-cloud-controller-manager
         resources:

--- a/templates/cluster-template-lb-kccm.yaml
+++ b/templates/cluster-template-lb-kccm.yaml
@@ -237,7 +237,8 @@ apiVersion: v1
 data:
   cloud-config: |
     loadBalancer:
-      creationPollInterval: 30
+      creationPollInterval: 5
+      creationPollTimeout: 60
     namespace: ${NAMESPACE}
     instancesV2:
       enabled: true
@@ -278,11 +279,11 @@ spec:
         - --cloud-provider=kubevirt
         - --cloud-config=/etc/cloud/cloud-config
         - --kubeconfig=/etc/kubernetes/kubeconfig/value
-        - --cluster-name=${CLUSTER_NAME}
         - --authentication-skip-lookup=true
+        - --cluster-name="${CLUSTER_NAME}"
         command:
         - /bin/kubevirt-cloud-controller-manager
-        image: quay.io/kubevirt/kubevirt-cloud-controller-manager:main
+        image: quay.io/kubevirt/kubevirt-cloud-controller-manager:v0.5.1
         imagePullPolicy: Always
         name: kubevirt-cloud-controller-manager
         resources:

--- a/templates/cluster-template-persistent-storage-kccm.yaml
+++ b/templates/cluster-template-persistent-storage-kccm.yaml
@@ -261,7 +261,8 @@ apiVersion: v1
 data:
   cloud-config: |
     loadBalancer:
-      creationPollInterval: 30
+      creationPollInterval: 5
+      creationPollTimeout: 60
     namespace: ${NAMESPACE}
     instancesV2:
       enabled: true
@@ -302,11 +303,11 @@ spec:
         - --cloud-provider=kubevirt
         - --cloud-config=/etc/cloud/cloud-config
         - --kubeconfig=/etc/kubernetes/kubeconfig/value
-        - --cluster-name=${CLUSTER_NAME}
         - --authentication-skip-lookup=true
+        - --cluster-name="${CLUSTER_NAME}"
         command:
         - /bin/kubevirt-cloud-controller-manager
-        image: quay.io/kubevirt/kubevirt-cloud-controller-manager:main
+        image: quay.io/kubevirt/kubevirt-cloud-controller-manager:v0.5.1
         imagePullPolicy: Always
         name: kubevirt-cloud-controller-manager
         resources:


### PR DESCRIPTION
**What this PR does / why we need it**:
The latest kccm fails if there are no IPs at LB services after some time, this change bump to it and configure the new timeout value.

```release-note
Bump kccm to v0.5.1 it will fail if there is no IPs at LB services after some time.
```
