### PR TITLE
Reflect the VM statuses to the KubeVirtCluster status

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,7 +54,7 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         args: --timeout=5m -v
-        version: v1.54.2
+        version: v1.55.2
 
   check-gen:
     runs-on: ubuntu-latest

--- a/api/v1alpha1/kubevirtmachine_types.go
+++ b/api/v1alpha1/kubevirtmachine_types.go
@@ -71,7 +71,7 @@ type VirtualMachineBootstrapCheckSpec struct {
 // KubevirtMachineStatus defines the observed state of KubevirtMachine.
 type KubevirtMachineStatus struct {
 	// Ready denotes that the machine is ready
-	// +optional
+	// +kubebuilder:default=false
 	Ready bool `json:"ready"`
 
 	// LoadBalancerConfigured denotes that the machine has been
@@ -134,6 +134,8 @@ type KubevirtMachineStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="Ready",type="boolean",JSONPath=".status.ready",description="Is machine ready"
 
 // KubevirtMachine is the Schema for the kubevirtmachines API.
 type KubevirtMachine struct {

--- a/clusterkubevirtadm/cmd/credentials/credentials.go
+++ b/clusterkubevirtadm/cmd/credentials/credentials.go
@@ -26,6 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sclient "k8s.io/client-go/kubernetes"
+	kubevirtcore "kubevirt.io/api/core"
+	cdicore "kubevirt.io/containerized-data-importer-api/pkg/apis/core"
 
 	"sigs.k8s.io/cluster-api-provider-kubevirt/clusterkubevirtadm/common"
 )
@@ -148,9 +150,14 @@ func generateRole(cmdCtx cmdContext) *rbacv1.Role {
 		},
 		Rules: []rbacv1.PolicyRule{
 			{
-				APIGroups: []string{"kubevirt.io"},
+				APIGroups: []string{kubevirtcore.GroupName},
 				Resources: []string{"virtualmachines", "virtualmachineinstances"},
 				Verbs:     []string{rbacv1.VerbAll},
+			},
+			{
+				APIGroups: []string{cdicore.GroupName},
+				Resources: []string{"datavolumes"},
+				Verbs:     []string{"get", "list", "watch"},
 			},
 			{
 				APIGroups: []string{""},

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_kubevirtmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_kubevirtmachines.yaml
@@ -18,7 +18,15 @@ spec:
     singular: kubevirtmachine
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Is machine ready
+      jsonPath: .status.ready
+      name: Ready
+      type: boolean
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: KubevirtMachine is the Schema for the kubevirtmachines API.
@@ -4614,8 +4622,11 @@ spec:
                   Node of this KubevirtMachine
                 type: boolean
               ready:
+                default: false
                 description: Ready denotes that the machine is ready
                 type: boolean
+            required:
+            - ready
             type: object
         type: object
     served: true

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -46,6 +46,14 @@ rules:
   - delete
   - list
 - apiGroups:
+  - cdi.kubevirt.io
+  resources:
+  - datavolumes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - cluster.x-k8s.io
   resources:
   - clusters

--- a/pkg/kubevirt/machine_factory.go
+++ b/pkg/kubevirt/machine_factory.go
@@ -38,6 +38,9 @@ type MachineInterface interface {
 	IsTerminal() (bool, string, error)
 
 	DrainNodeIfNeeded(workloadcluster.WorkloadCluster) (time.Duration, error)
+
+	// GetVMUnscheduledReason returns the reason and message for the condition, if the VM is not ready
+	GetVMNotReadyReason() (string, string)
 }
 
 // MachineFactory allows creating new instances of kubevirt.machine

--- a/pkg/kubevirt/mock/machine_factory_generated.go
+++ b/pkg/kubevirt/mock/machine_factory_generated.go
@@ -10,6 +10,7 @@ import (
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
+
 	context0 "sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
 	kubevirt "sigs.k8s.io/cluster-api-provider-kubevirt/pkg/kubevirt"
 	ssh "sigs.k8s.io/cluster-api-provider-kubevirt/pkg/ssh"
@@ -146,6 +147,10 @@ func (m *MockMachineInterface) IsReady() bool {
 	ret := m.ctrl.Call(m, "IsReady")
 	ret0, _ := ret[0].(bool)
 	return ret0
+}
+
+func (m *MockMachineInterface) GetVMNotReadyReason() (string, string) {
+	return "", ""
 }
 
 // IsReady indicates an expected call of IsReady.

--- a/pkg/testing/common.go
+++ b/pkg/testing/common.go
@@ -7,6 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	kubevirtv1 "kubevirt.io/api/core/v1"
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
 	infrav1 "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
@@ -188,23 +189,19 @@ func NewBootstrapDataSecret(userData []byte) *corev1.Secret {
 // SetupScheme setups the scheme for a fake client.
 func SetupScheme() *runtime.Scheme {
 	s := runtime.NewScheme()
-	if err := clusterv1.AddToScheme(s); err != nil {
-		panic(err)
+	for _, f := range []func(*runtime.Scheme) error{
+		clusterv1.AddToScheme,
+		infrav1.AddToScheme,
+		kubevirtv1.AddToScheme,
+		cdiv1.AddToScheme,
+		corev1.AddToScheme,
+		appsv1.AddToScheme,
+		rbacv1.AddToScheme,
+	} {
+		if err := f(s); err != nil {
+			panic(err)
+		}
 	}
-	if err := infrav1.AddToScheme(s); err != nil {
-		panic(err)
-	}
-	if err := kubevirtv1.AddToScheme(s); err != nil {
-		panic(err)
-	}
-	if err := corev1.AddToScheme(s); err != nil {
-		panic(err)
-	}
-	if err := appsv1.AddToScheme(s); err != nil {
-		panic(err)
-	}
-	if err := rbacv1.AddToScheme(s); err != nil {
-		panic(err)
-	}
+
 	return s
 }


### PR DESCRIPTION
## What this PR does / why we need it
Be more verbose when VM is not scheduled. Add meaningful reasons and messages to the KubeVirtMachine conditions, to be reflected in the Cluster resources.

Also, make the `KubeVirtMachine.status.ready` field to be printed also if it `false`, and adding it as a new printed column named "Rwady".

- [x] todo: complete unit tests
