### PR TITLE
Add condition to KubeVirtMachine when VM Creation Fails

### DIFF
--- a/api/v1alpha1/condition_consts.go
+++ b/api/v1alpha1/condition_consts.go
@@ -33,6 +33,10 @@ const (
 	// WaitingForBootstrapDataReason (Severity=Info) documents a KubevirtMachine waiting for the bootstrap
 	// script to be ready before starting to create the VM that provides the KubevirtMachine infrastructure.
 	WaitingForBootstrapDataReason = "WaitingForBootstrapData"
+
+	// VMCreateFailed (Severity=Error) documents a KubevirtMachine that is unable to create the
+	// corresponding VM object.
+	VMCreateFailedReason = "VMCreateFailed"
 )
 
 const (

--- a/controllers/kubevirtmachine_controller.go
+++ b/controllers/kubevirtmachine_controller.go
@@ -20,8 +20,9 @@ import (
 	gocontext "context"
 	"fmt"
 	"regexp"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v3"
@@ -264,6 +265,7 @@ func (r *KubevirtMachineReconciler) reconcileNormal(ctx *context.MachineContext)
 	if !isTerminal && !externalMachine.Exists() {
 		ctx.KubevirtMachine.Status.Ready = false
 		if err := externalMachine.Create(ctx.Context); err != nil {
+			conditions.MarkFalse(ctx.KubevirtMachine, infrav1.VMProvisionedCondition, infrav1.VMCreateFailedReason, clusterv1.ConditionSeverityError, fmt.Sprintf("Failed vm creation: %v", err))
 			return ctrl.Result{}, errors.Wrap(err, "failed to create VM instance")
 		}
 		ctx.Logger.Info("VM Created, waiting on vm to be provisioned.")


### PR DESCRIPTION
Currently, today if the VM creation fails for any reason, that is not directly reported on the KubeVirtMachine object which means visibility into the failure is not reported to the capi ecosystem.

This adds a condition to the KubeVirtMachine when creation fails so the capi ecosystem can report that failure and bubble it up to the various machine controllers.


```release-note
Adds condition to KubeVirtMachine when VM creation Fails
```
