### PR TITLE
fix: remove hostpath volume and privileged context

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -38,17 +38,8 @@ spec:
           httpGet:
             path: /healthz
             port: healthz
-        volumeMounts:
-          - mountPath: /var/run/docker.sock
-            name: dockersock
-        securityContext:
-          privileged: true
       terminationGracePeriodSeconds: 10
       serviceAccountName: manager
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
-      volumes:
-        - name: dockersock
-          hostPath:
-            path: /var/run/docker.sock


### PR DESCRIPTION
This change ensures the manager deployment meets restricted pod security
standards.

Fixes: https://github.com/kubernetes-sigs/cluster-api-provider-kubevirt/issues/274