### PR TITLE
Remove the setup counter from the KVMachine ready status

### DIFF
--- a/pkg/context/machine_context.go
+++ b/pkg/context/machine_context.go
@@ -66,7 +66,6 @@ func (c *MachineContext) PatchKubevirtMachine(patchHelper *patch.Helper) error {
 			infrav1.VMProvisionedCondition,
 			infrav1.BootstrapExecSucceededCondition,
 		),
-		conditions.WithStepCounterIf(c.KubevirtMachine.ObjectMeta.DeletionTimestamp.IsZero()),
 	)
 
 	// Patch the object, ignoring conflicts on the conditions owned by this controller.


### PR DESCRIPTION
## What this PR does / why we need it
Cluster-API takes the reason and the message from the infra-machine (in our case, the KubeVirtMachine) `Ready` condition, into the cluster-api `Machine`'s `InfrastructureReady` condition. Currently the text is something like `"0 of 2 completed"`. This is not very informative.

This PR changes the behavior so now the KV Machine Ready condition will include both the reason and the message from the failed condition.

That way, the cluster-api `InfrastructureReady` condition, will also contain the same reason and message. This will make the actual issue, if exists, to more accessible to the user.

**Release notes**:
```release-note
Remove the setup counter from the KV-Machine ready status
```
