### PR TITLE
Add new reason for failed vm

### DIFF
--- a/pkg/kubevirt/machine.go
+++ b/pkg/kubevirt/machine.go
@@ -283,15 +283,20 @@ func (m *Machine) getDVNotProvisionedReason(dv *cdiv1.DataVolume) (string, strin
 	case cdiv1.Failed:
 		return "DVFailed", msg, true
 	default:
+		reason := "DVNotReady"
 		for _, dvCond := range dv.Status.Conditions {
 			if dvCond.Type == cdiv1.DataVolumeRunning {
 				if dvCond.Status == corev1.ConditionFalse {
+					if dvCond.Reason == "ImagePullFailed" {
+						reason = "DVImagePullFailed"
+					}
+
 					msg = fmt.Sprintf("DataVolume %s import is not running: %s", dv.Name, dvCond.Message)
 				}
 				break
 			}
 		}
-		return "DVNotReady", msg, true
+		return reason, msg, true
 	}
 }
 

--- a/pkg/kubevirt/machine_test.go
+++ b/pkg/kubevirt/machine_test.go
@@ -956,6 +956,19 @@ var _ = Describe("check GetVMNotReadyReason", func() {
 				Conditions: []cdiv1.DataVolumeCondition{},
 			},
 		}, "DVNotReady", "is not ready; Phase: ImportInProgress"),
+		Entry("dv with Running condition and reason = 'ImagePullFailed'", &kubevirtv1.VirtualMachine{}, &cdiv1.DataVolume{
+			Status: cdiv1.DataVolumeStatus{
+				Phase: cdiv1.ImportInProgress,
+				Conditions: []cdiv1.DataVolumeCondition{
+					{
+						Type:    cdiv1.DataVolumeRunning,
+						Status:  corev1.ConditionFalse,
+						Reason:  "ImagePullFailed",
+						Message: "test message",
+					},
+				},
+			},
+		}, "DVImagePullFailed", "test message"),
 	)
 })
 


### PR DESCRIPTION
## What this PR does / why we need it
Support DV's new `ImagePullFailed` reason. Set the machine reason to `DVImagePullFailed`.

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Support DV's new `ImagePullFailed` reason. Set the machine reason to `DVImagePullFailed`.
```
