### PR TITLE
Add VM LiveMigratable Condition to KubevirtMachine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 
 # Build the manager binary
 # Run this with docker build --build-arg builder_image=<golang:x.y.z>
-ARG builder_image=golang:1.22
+ARG builder_image=docker.io/golang:1.22
 FROM ${builder_image} as builder
 WORKDIR /workspace
 

--- a/api/v1alpha1/condition_consts.go
+++ b/api/v1alpha1/condition_consts.go
@@ -37,6 +37,9 @@ const (
 	// VMCreateFailed (Severity=Error) documents a KubevirtMachine that is unable to create the
 	// corresponding VM object.
 	VMCreateFailedReason = "VMCreateFailed"
+
+	// VMLiveMigratableCondition documents whether the VM is live-migratable or not
+	VMLiveMigratableCondition clusterv1.ConditionType = "VMLiveMigratable"
 )
 
 const (

--- a/api/v1alpha1/kubevirtclustertemplate_types.go
+++ b/api/v1alpha1/kubevirtclustertemplate_types.go
@@ -24,7 +24,7 @@ import (
 // KubevirtClusterTemplateResource describes the data needed to create a KubevirtCluster from a template.
 type KubevirtClusterTemplateResource struct {
 	ObjectMeta clusterv1.ObjectMeta `json:"metadata,omitempty"`
-	Spec KubevirtClusterSpec `json:"spec"`
+	Spec       KubevirtClusterSpec  `json:"spec"`
 }
 
 // KubevirtClusterTemplateSpec defines the desired state of KubevirtClusterTemplate.
@@ -40,7 +40,7 @@ type KubevirtClusterTemplateSpec struct {
 type KubevirtClusterTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec KubevirtClusterTemplateSpec `json:"spec,omitempty"`
+	Spec              KubevirtClusterTemplateSpec `json:"spec,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/clusterkubevirtadm/cmd/credentials/credentials_test.go
+++ b/clusterkubevirtadm/cmd/credentials/credentials_test.go
@@ -2,6 +2,7 @@ package credentials
 
 import (
 	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/kubevirt/machine.go
+++ b/pkg/kubevirt/machine.go
@@ -237,6 +237,26 @@ func (m *Machine) IsReady() bool {
 	return m.hasReadyCondition()
 }
 
+// IsLiveMigratable reports back the live-migratability state of the VM: Status, Reason and Message
+func (m *Machine) IsLiveMigratable() (bool, string, string, error) {
+	if m.vmiInstance == nil {
+		return false, "", "", fmt.Errorf("VMI is nil")
+	}
+
+	for _, cond := range m.vmiInstance.Status.Conditions {
+		if cond.Type == kubevirtv1.VirtualMachineInstanceIsMigratable {
+			if cond.Status == corev1.ConditionTrue {
+				return true, "", "", nil
+			} else {
+				return false, cond.Reason, cond.Message, nil
+			}
+		}
+	}
+
+	return false, "", "", fmt.Errorf("%s VMI does not have a %s condition",
+		m.vmiInstance.Status.Phase, kubevirtv1.VirtualMachineInstanceIsMigratable)
+}
+
 const (
 	defaultCondReason  = "VMNotReady"
 	defaultCondMessage = "VM is not ready"

--- a/pkg/kubevirt/machine_factory.go
+++ b/pkg/kubevirt/machine_factory.go
@@ -25,6 +25,8 @@ type MachineInterface interface {
 	Exists() bool
 	// IsReady checks if the VM is ready
 	IsReady() bool
+	// IsLiveMigratable reports back the live-migratability state of the VM: Status, Reason and Message
+	IsLiveMigratable() (bool, string, string, error)
 	// Address returns the IP address of the VM.
 	Address() string
 	// SupportsCheckingIsBootstrapped checks if we have a method of checking

--- a/pkg/kubevirt/mock/machine_factory_generated.go
+++ b/pkg/kubevirt/mock/machine_factory_generated.go
@@ -10,7 +10,6 @@ import (
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
-
 	context0 "sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
 	kubevirt "sigs.k8s.io/cluster-api-provider-kubevirt/pkg/kubevirt"
 	ssh "sigs.k8s.io/cluster-api-provider-kubevirt/pkg/ssh"
@@ -127,6 +126,11 @@ func (mr *MockMachineInterfaceMockRecorder) GenerateProviderID() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateProviderID", reflect.TypeOf((*MockMachineInterface)(nil).GenerateProviderID))
 }
 
+// GetVMNotReadyReason mocks base method.
+func (m *MockMachineInterface) GetVMNotReadyReason() (string, string) {
+	return "", ""
+}
+
 // IsBootstrapped mocks base method.
 func (m *MockMachineInterface) IsBootstrapped() bool {
 	m.ctrl.T.Helper()
@@ -141,16 +145,29 @@ func (mr *MockMachineInterfaceMockRecorder) IsBootstrapped() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsBootstrapped", reflect.TypeOf((*MockMachineInterface)(nil).IsBootstrapped))
 }
 
+// IsLiveMigratable mocks base method.
+func (m *MockMachineInterface) IsLiveMigratable() (bool, string, string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsLiveMigratable")
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(string)
+	ret3, _ := ret[3].(error)
+	return ret0, ret1, ret2, ret3
+}
+
+// IsLiveMigratable indicates an expected call of IsLiveMigratable.
+func (mr *MockMachineInterfaceMockRecorder) IsLiveMigratable() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsLiveMigratable", reflect.TypeOf((*MockMachineInterface)(nil).IsLiveMigratable))
+}
+
 // IsReady mocks base method.
 func (m *MockMachineInterface) IsReady() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsReady")
 	ret0, _ := ret[0].(bool)
 	return ret0
-}
-
-func (m *MockMachineInterface) GetVMNotReadyReason() (string, string) {
-	return "", ""
 }
 
 // IsReady indicates an expected call of IsReady.

--- a/pkg/workloadcluster/mock/workloadcluster_generated.go
+++ b/pkg/workloadcluster/mock/workloadcluster_generated.go
@@ -9,8 +9,9 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	kubernetes "k8s.io/client-go/kubernetes"
-	context "sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
+
+	context "sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
 )
 
 // MockWorkloadCluster is a mock of WorkloadCluster interface.


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
Virtual Machines serving as guest cluster nodes can be live migrated, this is beneficial in case of infra cluster nodes maintainance or mulfunction,
requiring the Virtual Machines to be migrated to another node.
This PR introduces the "VMLiveMigratable" condition to KubevirtMachine, and it takes that value as-is from the underlying VirtualMachine instance.
Then, consumers of cluster-api-provider-kubevirt could make use of it and buble that information up to the end user.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
add VMLiveMigratable Condition to KubevirtMachine
```
