### PR TITLE
Allow annotate and label KubevirtClusterTemplates

### DIFF
--- a/api/v1alpha1/kubevirtclustertemplate_types.go
+++ b/api/v1alpha1/kubevirtclustertemplate_types.go
@@ -34,13 +34,13 @@ type KubevirtClusterTemplateSpec struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:path=kubevirtclustertemplates,scope=Namespaced,categories=cluster-api,shortName=kct
-// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="KubevirtClusterTemplate is immutable"
 
 // KubevirtClusterTemplate is the Schema for the kubevirtclustertemplates API.
 type KubevirtClusterTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              KubevirtClusterTemplateSpec `json:"spec,omitempty"`
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf", message="KubevirtClusterTemplate Spec is immutable"
+	Spec KubevirtClusterTemplateSpec `json:"spec,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_kubevirtclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_kubevirtclustertemplates.yaml
@@ -253,9 +253,9 @@ spec:
             required:
             - template
             type: object
+            x-kubernetes-validations:
+            - message: KubevirtClusterTemplate Spec is immutable
+              rule: self == oldSelf
         type: object
-        x-kubernetes-validations:
-        - message: KubevirtClusterTemplate is immutable
-          rule: self == oldSelf
     served: true
     storage: true


### PR DESCRIPTION
The current CRD does not allow modification of any field in KubevirtClusterTemplate resources. That prevent user to add annotations or labels to the templates, and that does not follow the regular behavior of K8s.

In addition, the new capi is trying to annotate templates, and failed to do that, and this is an actual bug.

This PR fixes the issue by making only the `Spec` field as read only, letting modifying the metadata fields as in any K8s resource.

Fixes #294 

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Allow annotate and label KubevirtClusterTemplate resources
```
