### PR TITLE
chore: add tilt provider file

### DIFF
--- a/tilt-provider.json
+++ b/tilt-provider.json
@@ -1,0 +1,17 @@
+[
+    {
+        "name": "kubevirt",
+        "config": {
+            "image": "controller",
+            "live_reload_deps": [
+                "main.go",
+                "go.mod",
+                "go.sum",
+                "api",
+                "pkg",
+                "controllers"
+            ],
+            "label": "CAPKV"
+        }
+    }
+]


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds a `tilt-provider.json` file to make it easier to use Tilt with the provider using the instructions from the [upstream CAPI docs](https://cluster-api.sigs.k8s.io/developer/tilt). 

To test, I used a tilt-settings.json file like this:

```json
{
  "enable_providers": [
    "kubeadm-bootstrap",
    "kubeadm-control-plane",
    "kubevirt"
  ],
  "default_registry": "gcr.io/richardcase",
  "provider_repos": [
    "/home/richard/code/oss/cluster-api-provider-kubevirt"
  ],
  "kustomize_substitutions": {
    "CLUSTER_TOPOLOGY": "true",
    "EXP_CLUSTER_RESOURCE_SET": "true",
    "EXP_MACHINE_POOL": "true"
  },
  "debug": {
    "kubevirt": {
      "continue": true,
      "port": 30000
    }
  }
}
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add tilt-provider file to enable Tilt development workflow.
```
