### PR TITLE
Remove caBundle placeholder in CRD webhooks

### DIFF
--- a/config/crd/patches/webhook_in_kubevirtclusters.yaml
+++ b/config/crd/patches/webhook_in_kubevirtclusters.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service

--- a/config/crd/patches/webhook_in_kubevirtmachines.yaml
+++ b/config/crd/patches/webhook_in_kubevirtmachines.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #331 

**Special notes for your reviewer**:


Changes Made: 
- Removes the caBundle: Cg== placeholder from config/crd/patches/webhook_in_kubevirtclusters.yaml 
- Removes associated comment explaining the placeholder's purpose 
- Removes the caBundle: Cg== placeholder from config/crd/patches/webhook_in_kubevirtmachines.yaml
- Removes associated comment explaining the placeholder's purpose

Starting with Kubernetes v1.31, the API server no longer accepts the newline placeholder (Cg==) as a valid caBundle value, causing webhook registration failures.

As documented in Kubernetes issue [#125569](https://github.com/kubernetes/kubernetes/issues/125569#issuecomment-2261245120), the Kubernetes API server behavior changed to be more strict about caBundle validation.


**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
