### PR TITLE
set go version to lower be generic v1.24, instead of specific v1.24.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api-provider-kubevirt
 
-go 1.24.7
+go 1.24.0
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
This will allow compiling in systems with older build images.

**Release notes**:
```release-note
None
```
