### PR TITLE
Add missing permission to the Upload Release Asset gh action

### DIFF
--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -29,6 +29,8 @@ jobs:
     name: Upload Release Asset
     needs: build-and-push-image
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
**Which issue this PR fixes**

Fixes #170

**Release notes**:
```release-note
None
```
