### PR TITLE
Fix the metadata file to match version v0.11.x

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -9,3 +9,9 @@ releaseSeries:
   - major: 0
     minor: 1
     contract: v1beta1
+  - major: 0
+    minor: 10
+    contract: v1beta1
+  - major: 0
+    minor: 11
+    contract: v1beta2


### PR DESCRIPTION
Fix #170

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix the metadata file to match version v0.11.x
```
