### PR TITLE
Force e2e integration pass before merging PRs

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -4,7 +4,7 @@ on:
   push: {}
 name: e2e
 jobs:
-  integration:
+  integration-tests:
     runs-on: ubuntu-latest
     if: (github.repository == 'kubernetes-sigs/cluster-api-provider-kubevirt') && contains(github.event.pull_request.labels.*.name, 'ok-to-test')
     strategy:
@@ -29,3 +29,16 @@ jobs:
       - name: Test
         run: |
           $GITHUB_WORKSPACE/project-infra/hack/mkpj.sh --job ${{ matrix.prowjobname }} --pull-number ${{github.event.number}} --kubeconfig $GITHUB_WORKSPACE/project-infra/.kubeconfig --trigger-job --fail-with-job
+
+  integration:
+    runs-on: ubuntu-latest
+    needs: integration-tests
+    if: github.repository == 'kubernetes-sigs/cluster-api-provider-kubevirt'
+    steps:
+      - name: Check integration status
+        run: |
+          if [[ "${{ needs.integration-tests.result }}" != "success" ]]; then
+            echo "Integration tests failed or were skipped"
+            exit 1
+          fi
+          echo "All integration tests passed"


### PR DESCRIPTION
**What this PR does / why we need it**:

The branch protection is managed from the
https://github.com/kubernetes/test-infra repository. It currently requires that the "Integration" job will pass. But since we now the integration is a matrics that creates two test lanes, then the "integration" rule is never satisfied.

This PR renames the original "integration" job, to "integration-tests", and adds new rollout job with the original name of "integration", to pass only if all the jobs defined by the matrix passed.

Now the existing "Integration" branch protection rule should work.

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Nonw
```
