### PR TITLE
Expose dual-stack addresses in KubevirtMachine status

### DIFF
--- a/controllers/kubevirtmachine_controller_test.go
+++ b/controllers/kubevirtmachine_controller_test.go
@@ -956,6 +956,7 @@ var _ = Describe("reconcile a kubevirt machine", func() {
 				machineMock.EXPECT().Address().Return("1.1.1.1").Times(1)
 				machineMock.EXPECT().SupportsCheckingIsBootstrapped().Return(false).Times(1)
 				machineMock.EXPECT().DrainNodeIfNeeded(gomock.Any()).Return(time.Duration(0), nil)
+				machineMock.EXPECT().Addresses().Return([]string{"1.1.1.1"}).Times(1)
 				machineMock.EXPECT().IsLiveMigratable().Return(false, "", "", nil).Times(1)
 
 				machineFactoryMock.EXPECT().NewMachine(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(machineMock, nil).Times(1)
@@ -1056,6 +1057,7 @@ var _ = Describe("reconcile a kubevirt machine", func() {
 				machineMock.EXPECT().SupportsCheckingIsBootstrapped().Return(true)
 				machineMock.EXPECT().IsBootstrapped().Return(true)
 				machineMock.EXPECT().DrainNodeIfNeeded(gomock.Any()).Return(time.Duration(0), nil)
+				machineMock.EXPECT().Addresses().Return([]string{"1.1.1.1"}).Times(1)
 				machineMock.EXPECT().IsLiveMigratable().Return(false, "", "", nil).Times(1)
 
 				machineFactoryMock.EXPECT().NewMachine(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(machineMock, nil).Times(1)
@@ -1112,6 +1114,7 @@ var _ = Describe("reconcile a kubevirt machine", func() {
 				machineMock.EXPECT().SupportsCheckingIsBootstrapped().Return(true)
 				machineMock.EXPECT().IsBootstrapped().Return(true)
 				machineMock.EXPECT().DrainNodeIfNeeded(gomock.Any()).Return(time.Duration(0), nil)
+				machineMock.EXPECT().Addresses().Return([]string{"1.1.1.1"}).Times(1)
 				machineMock.EXPECT().IsLiveMigratable().Return(true, "", "", nil).Times(1)
 
 				machineFactoryMock.EXPECT().NewMachine(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(machineMock, nil).Times(1)

--- a/pkg/kubevirt/machine.go
+++ b/pkg/kubevirt/machine.go
@@ -232,6 +232,20 @@ func (m *Machine) Address() string {
 	return ""
 }
 
+// Addresses returns all IP addresses of the VM (for dual-stack support).
+// It collects IPs from all network interfaces, supporting both IPv4 and IPv6.
+func (m *Machine) Addresses() []string {
+	if m.vmiInstance == nil {
+		return nil
+	}
+
+	var addresses []string
+	for _, iface := range m.vmiInstance.Status.Interfaces {
+		addresses = append(addresses, iface.IPs...)
+	}
+	return addresses
+}
+
 // IsReady checks if the VM is ready
 func (m *Machine) IsReady() bool {
 	return m.hasReadyCondition()

--- a/pkg/kubevirt/machine_factory.go
+++ b/pkg/kubevirt/machine_factory.go
@@ -29,6 +29,8 @@ type MachineInterface interface {
 	IsLiveMigratable() (bool, string, string, error)
 	// Address returns the IP address of the VM.
 	Address() string
+	// Addresses returns all IP addresses of the VM (for dual-stack support).
+	Addresses() []string
 	// SupportsCheckingIsBootstrapped checks if we have a method of checking
 	// that this bootstrapper has completed.
 	SupportsCheckingIsBootstrapped() bool

--- a/pkg/kubevirt/machine_test.go
+++ b/pkg/kubevirt/machine_test.go
@@ -118,6 +118,12 @@ var _ = Describe("Without KubeVirt VM running", func() {
 		Expect(externalMachine.Address()).To(Equal(""))
 	})
 
+	It("Addresses should return empty slice when VMI is nil", func() {
+		externalMachine, err := defaultTestMachine(machineContext, namespace, fakeClient, fakeVMCommandExecutor, []byte{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(externalMachine.Addresses()).To(BeEmpty())
+	})
+
 	It("IsReady should return false", func() {
 		externalMachine, err := defaultTestMachine(machineContext, namespace, fakeClient, fakeVMCommandExecutor, []byte{})
 		Expect(err).NotTo(HaveOccurred())
@@ -260,6 +266,37 @@ var _ = Describe("With KubeVirt VM running", func() {
 		externalMachine, err := defaultTestMachine(machineContext, namespace, fakeClient, fakeVMCommandExecutor, []byte(sshKey))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(externalMachine.Address()).To(Equal(virtualMachineInstance.Status.Interfaces[0].IP))
+	})
+
+	It("Addresses should return all IPs from interfaces", func() {
+		// Set up dual-stack IPs on the interface
+		virtualMachineInstance.Status.Interfaces[0].IPs = []string{"1.1.1.1", "2001:db8::1"}
+		fakeClient = fake.NewClientBuilder().WithScheme(testing.SetupScheme()).WithRuntimeObjects(cluster, kubevirtMachine, virtualMachine, virtualMachineInstance, bootstrapDataSecret).Build()
+
+		externalMachine, err := defaultTestMachine(machineContext, namespace, fakeClient, fakeVMCommandExecutor, []byte(sshKey))
+		Expect(err).NotTo(HaveOccurred())
+		addresses := externalMachine.Addresses()
+		Expect(addresses).To(HaveLen(2))
+		Expect(addresses).To(ContainElement("1.1.1.1"))
+		Expect(addresses).To(ContainElement("2001:db8::1"))
+	})
+
+	It("Addresses should return IPs from multiple interfaces", func() {
+		// Set up multiple interfaces with IPs
+		virtualMachineInstance.Status.Interfaces = []kubevirtv1.VirtualMachineInstanceNetworkInterface{
+			{IP: "1.1.1.1", IPs: []string{"1.1.1.1", "2001:db8::1"}},
+			{IP: "10.0.0.1", IPs: []string{"10.0.0.1", "2001:db8::2"}},
+		}
+		fakeClient = fake.NewClientBuilder().WithScheme(testing.SetupScheme()).WithRuntimeObjects(cluster, kubevirtMachine, virtualMachine, virtualMachineInstance, bootstrapDataSecret).Build()
+
+		externalMachine, err := defaultTestMachine(machineContext, namespace, fakeClient, fakeVMCommandExecutor, []byte(sshKey))
+		Expect(err).NotTo(HaveOccurred())
+		addresses := externalMachine.Addresses()
+		Expect(addresses).To(HaveLen(4))
+		Expect(addresses).To(ContainElement("1.1.1.1"))
+		Expect(addresses).To(ContainElement("2001:db8::1"))
+		Expect(addresses).To(ContainElement("10.0.0.1"))
+		Expect(addresses).To(ContainElement("2001:db8::2"))
 	})
 
 	It("IsReady should return true", func() {

--- a/pkg/kubevirt/mock/machine_factory_generated.go
+++ b/pkg/kubevirt/mock/machine_factory_generated.go
@@ -55,6 +55,20 @@ func (mr *MockMachineInterfaceMockRecorder) Address() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Address", reflect.TypeOf((*MockMachineInterface)(nil).Address))
 }
 
+// Addresses mocks base method.
+func (m *MockMachineInterface) Addresses() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Addresses")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// Addresses indicates an expected call of Addresses.
+func (mr *MockMachineInterfaceMockRecorder) Addresses() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Addresses", reflect.TypeOf((*MockMachineInterface)(nil).Addresses))
+}
+
 // Create mocks base method.
 func (m *MockMachineInterface) Create(ctx context.Context) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support for exposing all IP addresses (IPv4 and IPv6) in the KubevirtMachine status instead of just the primary IP. This fixes CSR auto-approval on dual-stack hosted control plane clusters where the machine-approver needs to see both IPv4 and IPv6 addresses.

Changes:
- Add Addresses() method to MachineInterface to retrieve all IPs from all VMI network interfaces
- Update controller to populate multiple InternalIP and ExternalIP entries for each address
- Add unit tests for dual-stack address handling


**Which issue this PR fixes** 
Fixes https://issues.redhat.com/browse/OCPBUGS-74338


**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Expose dual-stack addresses in KubevirtMachine status
```
