### PR TITLE
Add NodePort control plane endpoint support for KubeVirt clusters

### DIFF
--- a/controllers/kubevirtcluster_controller.go
+++ b/controllers/kubevirtcluster_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	gocontext "context"
 	"fmt"
+	"os"
 	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -190,7 +191,23 @@ func (r *KubevirtClusterReconciler) reconcileNormal(ctx *context.ClusterContext,
 			Port: 6443,
 		}
 
-		// Get Cluster IP if cluster Service Type is CusterIP
+		// Get NodePort if cluster Service Type is NodePort
+	} else if ctx.KubevirtCluster.Spec.ControlPlaneServiceTemplate.Spec.Type == "NodePort" {
+		if os.Getenv("FABRIC_HOST_OVERRIDE") == "" {
+			return ctrl.Result{}, errors.Errorf("NodePort selected but no FabricHostOverride specified")
+		}
+		if externalLoadBalancer.GetNodePort() == 0 {
+			conditions.MarkFalse(ctx.KubevirtCluster, infrav1.LoadBalancerAvailableCondition, infrav1.LoadBalancerProvisioningFailedReason, clusterv1.ConditionSeverityWarning, "NodePort not yet available")
+			return ctrl.Result{}, errors.Errorf("failed to get NodePort for the load balancer")
+		}
+
+		lbip4 := os.Getenv("FABRIC_HOST_OVERRIDE")
+		port := externalLoadBalancer.GetNodePort()
+		ctx.KubevirtCluster.Spec.ControlPlaneEndpoint = infrav1.APIEndpoint{
+			Host: lbip4,
+			Port: int(port),
+		}
+		// Get Cluster IP if cluster Service Type is ClusterIP
 	} else {
 		lbip4, err := externalLoadBalancer.IP(ctx)
 		if err != nil {

--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -121,6 +121,20 @@ func (l *LoadBalancer) Create(ctx *context.ClusterContext) error {
 	return nil
 }
 
+func (l *LoadBalancer) GetNodePort() int32 {
+	if !l.IsFound() {
+		return 0
+	}
+
+	for _, port := range l.service.Spec.Ports {
+		if port.Name == "ssh" {
+			return port.NodePort
+		}
+	}
+
+	return 0
+}
+
 // IP returns ip address of the load balancer
 func (l *LoadBalancer) IP(ctx *context.ClusterContext) (string, error) {
 	loadBalancer := &corev1.Service{}

--- a/pkg/loadbalancer/loadbalancer_test.go
+++ b/pkg/loadbalancer/loadbalancer_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -39,6 +40,7 @@ var (
 	kubevirtCluster     = testing.NewKubevirtCluster(clusterName, kubevirtClusterName)
 	cluster             = testing.NewCluster(clusterName, kubevirtCluster)
 	loadBalancerService = newLoadBalancerService(clusterContext, kubevirtCluster)
+	nodePortService     = newNodePortService(clusterContext, kubevirtCluster)
 
 	clusterContext = &context.ClusterContext{
 		Logger:          ctrl.LoggerFrom(gocontext.TODO()).WithName("test"),
@@ -70,6 +72,11 @@ var _ = Describe("Load Balancer", func() {
 
 		It("should return false for isFound()", func() {
 			Expect(lb.IsFound()).To(BeFalse())
+		})
+
+		It("should return nodePort as 0 for GetNodePort()", func() {
+			port := lb.GetNodePort()
+			Expect(port).To(Equal(int32(0)))
 		})
 
 		It("should return error for IP()", func() {
@@ -112,6 +119,36 @@ var _ = Describe("Load Balancer", func() {
 			Expect(err).To(HaveOccurred())
 		})
 	})
+
+	Context("when underlying service has been created already (NodePort service)", func() {
+		BeforeEach(func() {
+			objects := []client.Object{
+				cluster,
+				kubevirtCluster,
+				nodePortService,
+			}
+			fakeClient = fake.NewClientBuilder().WithScheme(testing.SetupScheme()).WithObjects(objects...).Build()
+		})
+
+		It("should initialize nodePort service without error", func() {
+			lb, err = loadbalancer.NewLoadBalancer(clusterContext, fakeClient, "")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return true for isFound()", func() {
+			Expect(lb.IsFound()).To(BeTrue())
+		})
+
+		It("should return non-empty nodePort", func() {
+			port := lb.GetNodePort()
+			Expect(port).ToNot(BeZero())
+		})
+
+		It("should NOT create a new load balancer", func() {
+			err = lb.Create(clusterContext)
+			Expect(err).To(HaveOccurred())
+		})
+	})
 })
 
 func newLoadBalancerService(ctx *context.ClusterContext, kubevirtCluster *infrav1.KubevirtCluster) *corev1.Service {
@@ -129,5 +166,33 @@ func newLoadBalancerService(ctx *context.ClusterContext, kubevirtCluster *infrav
 			},
 		},
 		Spec: corev1.ServiceSpec{ClusterIP: "1.1.1.1"},
+	}
+}
+
+func newNodePortService(ctx *context.ClusterContext, kubevirtCluster *infrav1.KubevirtCluster) *corev1.Service {
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: clusterName + "-lb",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					APIVersion: kubevirtCluster.APIVersion,
+					Kind:       kubevirtCluster.Kind,
+					Name:       kubevirtCluster.Name,
+					UID:        kubevirtCluster.UID,
+				},
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:       "ssh",
+					Port:       22,
+					NodePort:   30000,
+					Protocol:   corev1.ProtocolTCP,
+					TargetPort: intstr.FromInt(22),
+				},
+			},
+		},
 	}
 }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

- Extend KubeVirt cluster reconciliation to support ControlPlaneServiceTemplate type NodePort.
- When service type is NodePort, set ControlPlaneEndpoint host from FABRIC_HOST_OVERRIDE and port from the load balancer service NodePort.
- Fail reconciliation with a clear warning condition when FABRIC_HOST_OVERRIDE is missing or when the NodePort is not yet allocated.
- Add load balancer helper GetNodePort to read the NodePort from the ssh service port.
- Add/extend load balancer unit tests to cover:
  - missing service returns NodePort 0, 
  - existing NodePort service returns a non-zero NodePort, 
  - no duplicate load balancer creation when service already exists.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

https://github.com/kubernetes-sigs/cluster-api-provider-kubevirt/issues/338
