### PR TITLE
fix: set ownerReference on bootstrap userdata Secret to VM

### DIFF
--- a/controllers/kubevirtmachine_controller.go
+++ b/controllers/kubevirtmachine_controller.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	kubevirtv1 "kubevirt.io/api/core/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1" //nolint SA1019
 	capierrors "sigs.k8s.io/cluster-api/errors"          //nolint SA1019
 	"sigs.k8s.io/cluster-api/util"
@@ -591,6 +592,14 @@ func (r *KubevirtMachineReconciler) reconcileKubevirtBootstrapSecret(ctx *contex
 		}
 	}
 
+	// Fetch the VM if it already exists so we can wire an ownerReference from
+	// the bootstrap Secret to the VM.  On the first reconcile the VM will not
+	// exist yet (the Secret is created before the VM); the ownerReference is
+	// added on a subsequent reconcile once the VM is present.
+	vm := &kubevirtv1.VirtualMachine{}
+	vmKey := client.ObjectKey{Namespace: vmNamespace, Name: ctx.KubevirtMachine.Name}
+	vmFound := infraClusterClient.Get(ctx, vmKey, vm) == nil
+
 	newBootstrapDataSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      s.Name + "-userdata",
@@ -604,6 +613,17 @@ func (r *KubevirtMachineReconciler) reconcileKubevirtBootstrapSecret(ctx *contex
 		newBootstrapDataSecret.Type = clusterv1.ClusterSecretType
 		newBootstrapDataSecret.Data = map[string][]byte{
 			"userdata": value,
+		}
+
+		if vmFound {
+			newBootstrapDataSecret.SetOwnerReferences(util.EnsureOwnerRef(
+				newBootstrapDataSecret.OwnerReferences,
+				metav1.OwnerReference{
+					APIVersion: kubevirtv1.SchemeGroupVersion.String(),
+					Kind:       "VirtualMachine",
+					Name:       vm.Name,
+					UID:        vm.UID,
+				}))
 		}
 
 		return nil

--- a/controllers/kubevirtmachine_controller_test.go
+++ b/controllers/kubevirtmachine_controller_test.go
@@ -34,8 +34,8 @@ import (
 
 	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/kubevirt"
 
-	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"                //nolint SA1019
-	capierrors "sigs.k8s.io/cluster-api/errors"                          //nolint SA1019
+	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta1"         //nolint SA1019
+	capierrors "sigs.k8s.io/cluster-api/errors"                  //nolint SA1019
 	"sigs.k8s.io/cluster-api/util/deprecated/v1beta1/conditions" //nolint SA1019
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -503,6 +503,58 @@ var _ = Describe("reconcile a kubevirt machine", func() {
 		).To(Succeed())
 
 		Expect(bootstrapUserDataSecret.Data["userdata"]).To(Equal([]byte("shell-script")))
+	})
+
+	It("should set ownerReference on bootstrap Secret linking it to the VM", func() {
+		objects := []client.Object{
+			cluster,
+			kubevirtCluster,
+			machine,
+			kubevirtMachine,
+			sshKeySecret,
+			bootstrapSecret,
+		}
+
+		setupClient(kubevirt.DefaultMachineFactory{}, objects)
+
+		infraClusterMock.EXPECT().GenerateInfraClusterClient(
+			kubevirtMachine.Spec.InfraClusterSecretRef,
+			kubevirtMachine.Namespace,
+			machineContext.Context,
+		).Return(fakeClient, kubevirtMachine.Namespace, nil).Times(2)
+
+		// First reconcile: creates both VM and bootstrap userdata Secret.
+		// The Secret is created before the VM, so the ownerReference cannot
+		// be set yet.
+		out, err := kubevirtMachineReconciler.reconcileNormal(machineContext)
+		Expect(err).ShouldNot(HaveOccurred())
+		Expect(out).To(Equal(ctrl.Result{RequeueAfter: 20 * time.Second}))
+
+		createdVM := &kubevirtv1.VirtualMachine{}
+		vmKey := client.ObjectKey{Namespace: kubevirtMachine.Namespace, Name: kubevirtMachine.Name}
+		Expect(fakeClient.Get(gocontext.Background(), vmKey, createdVM)).To(Succeed())
+
+		secretKey := client.ObjectKey{
+			Namespace: kubevirtMachine.Namespace,
+			Name:      *machine.Spec.Bootstrap.DataSecretName + "-userdata",
+		}
+		bootstrapDataSecret := &corev1.Secret{}
+		Expect(fakeClient.Get(gocontext.Background(), secretKey, bootstrapDataSecret)).To(Succeed())
+		Expect(bootstrapDataSecret.OwnerReferences).To(BeEmpty(),
+			"ownerReference should not be set on first reconcile because VM did not exist when Secret was created")
+
+		// Second reconcile: the VM now exists, so the Secret should be
+		// updated with an ownerReference to the VM.
+		_, err = kubevirtMachineReconciler.reconcileNormal(machineContext)
+		Expect(err).ShouldNot(HaveOccurred())
+
+		Expect(fakeClient.Get(gocontext.Background(), secretKey, bootstrapDataSecret)).To(Succeed())
+		Expect(bootstrapDataSecret.OwnerReferences).To(HaveLen(1))
+		ownerRef := bootstrapDataSecret.OwnerReferences[0]
+		Expect(ownerRef.Kind).To(Equal("VirtualMachine"))
+		Expect(ownerRef.Name).To(Equal(kubevirtMachine.Name))
+		Expect(ownerRef.UID).To(Equal(createdVM.UID))
+		Expect(ownerRef.APIVersion).To(Equal(kubevirtv1.SchemeGroupVersion.String()))
 	})
 
 	It("should be able to delete KubeVirt VM even when cluster objects don't exist", func() {

--- a/pkg/capiv1beta1/map_func.go
+++ b/pkg/capiv1beta1/map_func.go
@@ -3,13 +3,14 @@ package capiv1beta1
 import (
 	context "context"
 
-	infrav1 "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
 	clusterv1v1beta1 "sigs.k8s.io/cluster-api/api/core/v1beta1" //nolint SA1019
 	clusterv1 "sigs.k8s.io/cluster-api/api/core/v1beta2"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	infrav1 "sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
 )
 
 func MapV1beta1MachineToKVMachine(ctx context.Context, object client.Object) []reconcile.Request {


### PR DESCRIPTION
**What this PR does / why we need it**:

Sets an ownerReference from the `-userdata` bootstrap Secret to its VirtualMachine in `reconcileKubevirtBootstrapSecret`. This establishes a Kubernetes-level lifecycle relationship between the two resources, providing cascading cleanup (VM deleted -> Secret garbage-collected) and allowing external controllers to determine the Secret is still in use.

Without this, the `-userdata` Secret can be orphaned if `reconcileDelete` fails, or prematurely cleaned up by higher-level orchestrators (e.g. HyperShift) that do not know the Secret is still referenced by a running VM.

On the first reconcile the Secret is created before the VM, so the ownerReference cannot be set yet. It is added on a subsequent reconcile once the VM is present.

**Special notes for your reviewer**:

- The existing `reconcileDelete` path continues to explicitly delete the Secret before the VM (deterministic ordering). The ownerReference is a safety net, not a replacement for explicit deletion.
- `pkg/capiv1beta1/map_func.go` has a pre-existing `goimports` formatting change included per CONTRIBUTING.md ("run `make sanity`... commit these files before pushing").
- `make sanity` passes cleanly (linter 0 issues, goimports, 129 unit tests).

```release-note
Set ownerReference on bootstrap userdata Secret linking it to the VirtualMachine for proper lifecycle management
```

Made with [Cursor](https://cursor.com)