### PR TITLE
[PoC] cloud-init: NoCloud volume with annotation-driven inline networkData

### DIFF
--- a/pkg/kubevirt/machine_test.go
+++ b/pkg/kubevirt/machine_test.go
@@ -647,6 +647,72 @@ var _ = Describe("util functions", func() {
 		Expect(newVM.Spec.DataVolumeTemplates[0].ObjectMeta.Name).To(Equal(kubevirtMachineName + "-dv1"))
 		Expect(newVM.Spec.Template.Spec.Volumes[0].VolumeSource.DataVolume.Name).To(Equal(kubevirtMachineName + "-dv1"))
 	})
+
+	Context("buildVirtualMachineInstanceTemplate cloud-init volume", func() {
+		findCloudInitVolumes := func(template *kubevirtv1.VirtualMachineInstanceTemplateSpec) []kubevirtv1.Volume {
+			var cloudInitVolumes []kubevirtv1.Volume
+			for _, volume := range template.Spec.Volumes {
+				if volume.CloudInitNoCloud != nil || volume.CloudInitConfigDrive != nil {
+					cloudInitVolumes = append(cloudInitVolumes, volume)
+				}
+			}
+			return cloudInitVolumes
+		}
+
+		It("without network-data annotation, should add a single NoCloud volume with userDataSecretRef and no networkData", func() {
+			template := buildVirtualMachineInstanceTemplate(machineContext)
+
+			cloudInitVolumes := findCloudInitVolumes(template)
+			Expect(cloudInitVolumes).To(HaveLen(1))
+			Expect(cloudInitVolumes[0].Name).To(Equal("cloudinitvolume"))
+			Expect(cloudInitVolumes[0].CloudInitConfigDrive).To(BeNil())
+			Expect(cloudInitVolumes[0].CloudInitNoCloud).ToNot(BeNil())
+			Expect(cloudInitVolumes[0].CloudInitNoCloud.UserDataSecretRef.Name).To(Equal("fakeDataSecretName-userdata"))
+			Expect(cloudInitVolumes[0].CloudInitNoCloud.NetworkData).To(BeEmpty())
+		})
+
+		It("with network-data annotation, should populate networkData alongside userDataSecretRef", func() {
+			networkData := "version: 2\nethernets:\n  eth0:\n    dhcp4: true"
+			machineContext.KubevirtMachine.Spec.VirtualMachineTemplate.ObjectMeta.Annotations = map[string]string{
+				NetworkDataAnnotation: networkData,
+			}
+
+			template := buildVirtualMachineInstanceTemplate(machineContext)
+
+			cloudInitVolumes := findCloudInitVolumes(template)
+			Expect(cloudInitVolumes).To(HaveLen(1))
+			Expect(cloudInitVolumes[0].CloudInitNoCloud).ToNot(BeNil())
+			Expect(cloudInitVolumes[0].CloudInitNoCloud.UserDataSecretRef.Name).To(Equal("fakeDataSecretName-userdata"))
+			Expect(cloudInitVolumes[0].CloudInitNoCloud.NetworkData).To(Equal(networkData))
+		})
+
+		It("with empty network-data annotation, should not set networkData", func() {
+			machineContext.KubevirtMachine.Spec.VirtualMachineTemplate.ObjectMeta.Annotations = map[string]string{
+				NetworkDataAnnotation: "",
+			}
+
+			template := buildVirtualMachineInstanceTemplate(machineContext)
+
+			cloudInitVolumes := findCloudInitVolumes(template)
+			Expect(cloudInitVolumes).To(HaveLen(1))
+			Expect(cloudInitVolumes[0].CloudInitNoCloud).ToNot(BeNil())
+			Expect(cloudInitVolumes[0].CloudInitNoCloud.NetworkData).To(BeEmpty())
+		})
+
+		It("should add a matching virtio disk for the cloud-init volume", func() {
+			template := buildVirtualMachineInstanceTemplate(machineContext)
+
+			var cloudInitDisks []kubevirtv1.Disk
+			for _, disk := range template.Spec.Domain.Devices.Disks {
+				if disk.Name == "cloudinitvolume" {
+					cloudInitDisks = append(cloudInitDisks, disk)
+				}
+			}
+			Expect(cloudInitDisks).To(HaveLen(1))
+			Expect(cloudInitDisks[0].Disk).ToNot(BeNil())
+			Expect(cloudInitDisks[0].Disk.Bus).To(Equal(kubevirtv1.DiskBusVirtio))
+		})
+	})
 })
 
 var _ = Describe("With KubeVirt VM running externally", func() {

--- a/pkg/kubevirt/utils.go
+++ b/pkg/kubevirt/utils.go
@@ -28,6 +28,11 @@ import (
 	"sigs.k8s.io/cluster-api-provider-kubevirt/pkg/context"
 )
 
+// NetworkDataAnnotation, when present on the VirtualMachineTemplate metadata of a
+// KubevirtMachine, provides inline cloud-init network data (e.g. netplan v2) that is
+// attached to the generated cloud-init NoCloud volume alongside the bootstrap userdata.
+const NetworkDataAnnotation = "capk.cluster.x-k8s.io/cloud-init-network-data"
+
 type CommandExecutor interface {
 	ExecuteCommand(command string) (string, error)
 }
@@ -139,14 +144,18 @@ func buildVirtualMachineInstanceTemplate(ctx *context.MachineContext) *kubevirtv
 	template.Spec = *ctx.KubevirtMachine.Spec.VirtualMachineTemplate.Spec.Template.Spec.DeepCopy()
 
 	cloudInitVolumeName := "cloudinitvolume"
+	cloudInitNoCloud := &kubevirtv1.CloudInitNoCloudSource{
+		UserDataSecretRef: &corev1.LocalObjectReference{
+			Name: *ctx.Machine.Spec.Bootstrap.DataSecretName + "-userdata",
+		},
+	}
+	if networkData := ctx.KubevirtMachine.Spec.VirtualMachineTemplate.ObjectMeta.Annotations[NetworkDataAnnotation]; networkData != "" {
+		cloudInitNoCloud.NetworkData = networkData
+	}
 	cloudInitVolume := kubevirtv1.Volume{
 		Name: cloudInitVolumeName,
 		VolumeSource: kubevirtv1.VolumeSource{
-			CloudInitConfigDrive: &kubevirtv1.CloudInitConfigDriveSource{
-				UserDataSecretRef: &corev1.LocalObjectReference{
-					Name: *ctx.Machine.Spec.Bootstrap.DataSecretName + "-userdata",
-				},
-			},
+			CloudInitNoCloud: cloudInitNoCloud,
 		},
 	}
 	template.Spec.Volumes = append(template.Spec.Volumes, cloudInitVolume)


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

PoC: delivers per-NodePool cloud-init `networkData` to HyperShift KubeVirt worker VMs with a CAPK-only change.

- Switches the generated cloud-init volume from `CloudInitConfigDrive` to `CloudInitNoCloud` (ignition supports NoCloud; enables afterburn netplan-v2 translation of networkData in RHCOS guests).
- Adds annotation contract `capk.cluster.x-k8s.io/cloud-init-network-data` on `KubevirtMachine.Spec.VirtualMachineTemplate.ObjectMeta.Annotations`: when present and non-empty, its value is set as inline `networkData` on the NoCloud source, alongside the existing `userDataSecretRef`.

The annotation is reachable from HyperShift's existing `hypershift.openshift.io/kubevirt-vm-jsonpatch` NodePool annotation (patch root = `VirtualMachineTemplate`), so per-NodePool network config works without any HyperShift changes. A typed `KubevirtMachineSpec` field would not be reachable from that jsonpatch.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: N/A

**Special notes for your reviewer**:

Draft / PoC — not intended to merge as-is:

- Always-NoCloud is PoC-only; an upstreamable version needs an opt-in gate (annotation-gated datasource type or typed API field) since this changes the datasource for all existing users.
- Inline networkData only; KubeVirt admitter caps inline networkData at 2048 bytes. `networkDataSecretRef` variant is future work.
- Related standalone bug: today a user-supplied cloud-init volume in the VM template yields a broken dual-cloud-init-volume VMI (virt-launcher uses only the first; mixed types fail domain start). Honoring a pre-existing cloud-init volume could be a separate fix.

Tests: 4 new specs in `pkg/kubevirt/machine_test.go` covering no-annotation (single NoCloud volume, userDataSecretRef, empty networkData), annotation set, empty annotation, and matching virtio disk. `make test` green.

**Release notes**:

```release-note
NONE
```
