### PR TITLE
bump all gh actions to their latest versions

### DIFF
--- a/.github/workflows/clusterkubevirtadm-test.yaml
+++ b/.github/workflows/clusterkubevirtadm-test.yaml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 #v6.5.0
       with:
         go-version-file: go.mod
     - name: Test

--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 #v4.2.0
       - name: build image
         shell: bash
         env:
@@ -33,9 +33,9 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 #v6.5.0
         with:
           go-version-file: go.mod
       - name: Install kustomize
@@ -48,7 +48,7 @@ jobs:
         run: |
           make create-infrastructure-components
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@2bb465e97f322d3cb2a965294d483e0d26a67aa9 #v3.0.1
         with:
           generate_release_notes: true
           fail_on_unmatched_files: true

--- a/.github/workflows/image_build.yaml
+++ b/.github/workflows/image_build.yaml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 #v4.2.0
       - name: build image
         shell: bash
         env:

--- a/.github/workflows/pr-gh-workflow-approve.yaml
+++ b/.github/workflows/pr-gh-workflow-approve.yaml
@@ -17,7 +17,7 @@ jobs:
       actions: write
     steps:
       - name: Update PR
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 #v9.0.0
         continue-on-error: true
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 #v6.5.0
       with:
         go-version-file: go.mod
     - name: Test
@@ -24,9 +24,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 #v6.5.0
       with:
         go-version-file: go.mod
     - name: Test with coverage
@@ -47,13 +47,13 @@ jobs:
     if: github.repository == 'kubernetes-sigs/cluster-api-provider-kubevirt'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 #v6.5.0
       with:
         go-version-file: go.mod
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v7
+      uses: golangci/golangci-lint-action@d583c34f0599d37dbac4a198b9c83201be380893 #v9.3.0
       with:
         args: --timeout=5m -v
         version: v2.11.2
@@ -62,9 +62,9 @@ jobs:
     if: github.repository == 'kubernetes-sigs/cluster-api-provider-kubevirt'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
     - name: Install Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 #v6.5.0
       with:
         go-version-file: go.mod
     - name: Check that 'make generate' has being call


### PR DESCRIPTION
kubernetes-sigs new policy forbids using floating github-action tags in github workflows, and forces a specific git sha instead.

This PR bump all the imported actions to their latest versions, and uses a git shas instead of floating tags.

> **Note**: the e2e workflow is running the version of the target branch, instead of the version in pull request. The meaning for it is that this action is not fixable using a pull request, because the policy fails this workflow.
>
> To solve it I had to directly push a fix to the main branch; see commit f4d655feb12a3cedc6dbf1e4da3932a984f34aba, where I did the same (replacing the action floating tags with the latest git shas), in the e2e workflow.

**Release notes**
```release-note
None
```
