### PR TITLE
OCPBUGS-98218: Fix guest node remaining cordoned after VMI eviction and restart

### DIFF
--- a/api/v1alpha1/kubevirtcluster_types.go
+++ b/api/v1alpha1/kubevirtcluster_types.go
@@ -38,6 +38,12 @@ const ( // labels
 const ( // annotations
 	VmiDeletionGraceTime       = "capk.cluster.x-k8s.io/vmi-deletion-grace-time"
 	VmiDeletionGraceTimeEscape = "capk.cluster.x-k8s.io~1vmi-deletion-grace-time"
+
+	// NodeCordonedByCapk is set on KubevirtMachine when CAPK cordons the
+	// guest node during an eviction drain. It is used to uncordon the node
+	// after the VMI is recreated on a different host.
+	NodeCordonedByCapk       = "capk.cluster.x-k8s.io/node-cordoned"
+	NodeCordonedByCapkEscape = "capk.cluster.x-k8s.io~1node-cordoned"
 )
 
 // KubevirtClusterSpec defines the desired state of KubevirtCluster.

--- a/pkg/kubevirt/machine.go
+++ b/pkg/kubevirt/machine.go
@@ -433,6 +433,17 @@ func (m *Machine) DrainNodeIfNeeded(wrkldClstr workloadcluster.WorkloadCluster) 
 				return 100 * time.Millisecond, err
 			}
 		}
+
+		// Only uncordon when the VMI is back and not being deleted. If the VMI
+		// is nil (not yet recreated) or still has a DeletionTimestamp, the
+		// eviction cycle is not complete and the node must stay cordoned.
+		if m.vmiInstance != nil && m.vmiInstance.DeletionTimestamp == nil {
+			if err := m.uncordonNodeIfNeeded(wrkldClstr); err != nil {
+				m.machineContext.Logger.Error(err, "failed to uncordon guest node")
+				return 100 * time.Millisecond, nil
+			}
+		}
+
 		return 0, nil
 	}
 
@@ -478,6 +489,72 @@ func (m *Machine) removeGracePeriodAnnotation() error {
 	}
 
 	return nil
+}
+
+func (m *Machine) setNodeCordonedAnnotation() error {
+	patch := fmt.Sprintf(`{"metadata":{"annotations":{"%s": "true"}}}`, infrav1.NodeCordonedByCapk)
+	patchRequest := client.RawPatch(types.MergePatchType, []byte(patch))
+
+	if err := m.client.Patch(m.machineContext, m.machineContext.KubevirtMachine, patchRequest); err != nil {
+		return fmt.Errorf("failed to set the %s annotation on KubeVirtMachine %s; %w", infrav1.NodeCordonedByCapk, m.machineContext.KubevirtMachine.Name, err)
+	}
+
+	return nil
+}
+
+const removeNodeCordonedAnnotationPatch = `[{"op": "remove", "path": "/metadata/annotations/` + infrav1.NodeCordonedByCapkEscape + `"}]`
+
+func (m *Machine) removeNodeCordonedAnnotation() error {
+	patch := client.RawPatch(types.JSONPatchType, []byte(removeNodeCordonedAnnotationPatch))
+
+	if err := m.client.Patch(m.machineContext, m.machineContext.KubevirtMachine, patch); err != nil {
+		return fmt.Errorf("failed to remove the %s annotation from KubeVirtMachine %s; %w", infrav1.NodeCordonedByCapk, m.machineContext.KubevirtMachine.Name, err)
+	}
+
+	return nil
+}
+
+func (m *Machine) uncordonNodeIfNeeded(wrkldClstr workloadcluster.WorkloadCluster) error {
+	if _, exists := m.machineContext.KubevirtMachine.Annotations[infrav1.NodeCordonedByCapk]; !exists {
+		return nil
+	}
+
+	if wrkldClstr == nil {
+		m.machineContext.Logger.Info("Workload cluster client is nil, skipping uncordon")
+		return nil
+	}
+
+	kubeClient, err := wrkldClstr.GenerateWorkloadClusterK8sClient(m.machineContext)
+	if err != nil {
+		return fmt.Errorf("failed to get client to remote cluster for uncordon; %w", err)
+	}
+
+	nodeName := m.machineContext.KubevirtMachine.Name
+	node, err := kubeClient.CoreV1().Nodes().Get(m.machineContext, nodeName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			m.machineContext.Logger.Info("Node not found during uncordon, removing annotation", "node", nodeName)
+			return m.removeNodeCordonedAnnotation()
+		}
+		return fmt.Errorf("unable to get node %q for uncordon: %w", nodeName, err)
+	}
+
+	if !node.Spec.Unschedulable {
+		m.machineContext.Logger.Info("Node is already schedulable, removing stale cordon annotation", "node", nodeName)
+		return m.removeNodeCordonedAnnotation()
+	}
+
+	drainer := &kubedrain.Helper{
+		Client: kubeClient,
+		Ctx:    m.machineContext,
+	}
+
+	m.machineContext.Logger.Info("Uncordoning guest node after VMI restart", "node", nodeName)
+	if err = kubedrain.RunCordonOrUncordon(drainer, node, false); err != nil {
+		return fmt.Errorf("unable to uncordon node %s: %w", nodeName, err)
+	}
+
+	return m.removeNodeCordonedAnnotation()
 }
 
 func (m *Machine) shouldGracefulDeleteVMI() bool {
@@ -590,6 +667,11 @@ func (m *Machine) drainNode(wrkldClstr workloadcluster.WorkloadCluster) (time.Du
 		// Machine will be re-reconciled after a cordon failure.
 		m.machineContext.Logger.Error(err, "Cordon failed")
 		return 0, errors.Errorf("unable to cordon node %s: %v", nodeName, err)
+	}
+
+	if err = m.setNodeCordonedAnnotation(); err != nil {
+		m.machineContext.Logger.Error(err, "Failed to set node-cordoned annotation after cordon")
+		return 100 * time.Millisecond, nil
 	}
 
 	if err = kubedrain.RunNodeDrain(drainer, node.Name); err != nil {

--- a/pkg/kubevirt/machine_test.go
+++ b/pkg/kubevirt/machine_test.go
@@ -523,6 +523,9 @@ var _ = Describe("With KubeVirt VM running", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(machine).ToNot(BeNil())
 				Expect(machine.Annotations).ToNot(HaveKey(v1alpha1.VmiDeletionGraceTime))
+
+				By("The node-cordoned annotation should be set after cordon")
+				Expect(machine.Annotations).To(HaveKey(v1alpha1.NodeCordonedByCapk))
 			})
 		})
 
@@ -598,6 +601,245 @@ var _ = Describe("With KubeVirt VM running", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(machine).ToNot(BeNil())
 				Expect(machine.Annotations).ToNot(HaveKey(v1alpha1.VmiDeletionGraceTime))
+			})
+		})
+
+		When("VMI was recreated after eviction and guest node is still cordoned", func() {
+			BeforeEach(func() {
+				virtualMachineInstance.Spec.EvictionStrategy = nil
+				virtualMachineInstance.Status.EvacuationNodeName = ""
+				kubevirtMachine.Annotations[v1alpha1.NodeCordonedByCapk] = "true"
+			})
+
+			It("Should uncordon the guest node and remove the annotation", func() {
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: kubevirtMachineName,
+					},
+					Spec: corev1.NodeSpec{
+						Unschedulable: true,
+					},
+				}
+
+				Expect(k8sfake.AddToScheme(setupRemoteScheme())).ToNot(HaveOccurred())
+				cl := k8sfake.NewClientset(node)
+
+				wlCluster.EXPECT().GenerateWorkloadClusterK8sClient(gomock.Any()).Return(cl, nil).Times(1)
+
+				externalMachine, err := defaultTestMachine(machineContext, namespace, fakeClient, fakeVMCommandExecutor, []byte(sshKey))
+				Expect(err).NotTo(HaveOccurred())
+
+				requeueDuration, err := externalMachine.DrainNodeIfNeeded(wlCluster)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(requeueDuration).Should(BeZero())
+
+				By("Guest node should be uncordoned")
+				updatedNode, err := cl.CoreV1().Nodes().Get(gocontext.Background(), kubevirtMachineName, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updatedNode.Spec.Unschedulable).To(BeFalse())
+
+				By("The node-cordoned annotation should be removed")
+				kvMachine := &v1alpha1.KubevirtMachine{}
+				err = fakeClient.Get(gocontext.Background(), client.ObjectKey{Namespace: kubevirtMachine.Namespace, Name: kubevirtMachine.Name}, kvMachine)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(kvMachine.Annotations).ToNot(HaveKey(v1alpha1.NodeCordonedByCapk))
+			})
+		})
+
+		When("VMI was recreated but guest node is already schedulable", func() {
+			BeforeEach(func() {
+				virtualMachineInstance.Spec.EvictionStrategy = nil
+				virtualMachineInstance.Status.EvacuationNodeName = ""
+				kubevirtMachine.Annotations[v1alpha1.NodeCordonedByCapk] = "true"
+			})
+
+			It("Should just remove the stale annotation", func() {
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: kubevirtMachineName,
+					},
+					Spec: corev1.NodeSpec{
+						Unschedulable: false,
+					},
+				}
+
+				Expect(k8sfake.AddToScheme(setupRemoteScheme())).ToNot(HaveOccurred())
+				cl := k8sfake.NewClientset(node)
+
+				wlCluster.EXPECT().GenerateWorkloadClusterK8sClient(gomock.Any()).Return(cl, nil).Times(1)
+
+				externalMachine, err := defaultTestMachine(machineContext, namespace, fakeClient, fakeVMCommandExecutor, []byte(sshKey))
+				Expect(err).NotTo(HaveOccurred())
+
+				requeueDuration, err := externalMachine.DrainNodeIfNeeded(wlCluster)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(requeueDuration).Should(BeZero())
+
+				By("The node-cordoned annotation should be removed")
+				kvMachine := &v1alpha1.KubevirtMachine{}
+				err = fakeClient.Get(gocontext.Background(), client.ObjectKey{Namespace: kubevirtMachine.Namespace, Name: kubevirtMachine.Name}, kvMachine)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(kvMachine.Annotations).ToNot(HaveKey(v1alpha1.NodeCordonedByCapk))
+			})
+		})
+
+		When("No cordon annotation exists and no eviction in progress", func() {
+			BeforeEach(func() {
+				virtualMachineInstance.Spec.EvictionStrategy = nil
+				virtualMachineInstance.Status.EvacuationNodeName = ""
+			})
+
+			It("Should not attempt to uncordon", func() {
+				wlCluster.EXPECT().GenerateWorkloadClusterK8sClient(gomock.Any()).Times(0)
+
+				externalMachine, err := defaultTestMachine(machineContext, namespace, fakeClient, fakeVMCommandExecutor, []byte(sshKey))
+				Expect(err).NotTo(HaveOccurred())
+
+				requeueDuration, err := externalMachine.DrainNodeIfNeeded(wlCluster)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(requeueDuration).Should(BeZero())
+			})
+		})
+
+		When("VMI still has DeletionTimestamp with cordon annotation present", func() {
+			BeforeEach(func() {
+				deletionTimeStamp := metav1.NewTime(time.Now().UTC().Add(-5 * time.Second))
+				virtualMachineInstance.DeletionTimestamp = &deletionTimeStamp
+				virtualMachineInstance.Finalizers = []string{"fake/finalizer"}
+				kubevirtMachine.Annotations[v1alpha1.NodeCordonedByCapk] = "true"
+			})
+
+			It("Should not uncordon while VMI is still being deleted", func() {
+				wlCluster.EXPECT().GenerateWorkloadClusterK8sClient(gomock.Any()).Times(0)
+
+				externalMachine, err := defaultTestMachine(machineContext, namespace, fakeClient, fakeVMCommandExecutor, []byte(sshKey))
+				Expect(err).NotTo(HaveOccurred())
+
+				requeueDuration, err := externalMachine.DrainNodeIfNeeded(wlCluster)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(requeueDuration).Should(BeZero())
+
+				By("The node-cordoned annotation should still be present")
+				kvMachine := &v1alpha1.KubevirtMachine{}
+				err = fakeClient.Get(gocontext.Background(), client.ObjectKey{Namespace: kubevirtMachine.Namespace, Name: kubevirtMachine.Name}, kvMachine)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(kvMachine.Annotations).To(HaveKey(v1alpha1.NodeCordonedByCapk))
+			})
+		})
+
+		When("VMI was recreated and guest node is not found", func() {
+			BeforeEach(func() {
+				virtualMachineInstance.Spec.EvictionStrategy = nil
+				virtualMachineInstance.Status.EvacuationNodeName = ""
+				kubevirtMachine.Annotations[v1alpha1.NodeCordonedByCapk] = "true"
+			})
+
+			It("Should remove the annotation when node is not found", func() {
+				Expect(k8sfake.AddToScheme(setupRemoteScheme())).ToNot(HaveOccurred())
+				cl := k8sfake.NewClientset()
+
+				wlCluster.EXPECT().GenerateWorkloadClusterK8sClient(gomock.Any()).Return(cl, nil).Times(1)
+
+				externalMachine, err := defaultTestMachine(machineContext, namespace, fakeClient, fakeVMCommandExecutor, []byte(sshKey))
+				Expect(err).NotTo(HaveOccurred())
+
+				requeueDuration, err := externalMachine.DrainNodeIfNeeded(wlCluster)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(requeueDuration).Should(BeZero())
+
+				By("The node-cordoned annotation should be removed")
+				kvMachine := &v1alpha1.KubevirtMachine{}
+				err = fakeClient.Get(gocontext.Background(), client.ObjectKey{Namespace: kubevirtMachine.Namespace, Name: kubevirtMachine.Name}, kvMachine)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(kvMachine.Annotations).ToNot(HaveKey(v1alpha1.NodeCordonedByCapk))
+			})
+		})
+
+		When("Cordon annotation present but workload cluster is nil", func() {
+			BeforeEach(func() {
+				virtualMachineInstance.Spec.EvictionStrategy = nil
+				virtualMachineInstance.Status.EvacuationNodeName = ""
+				kubevirtMachine.Annotations[v1alpha1.NodeCordonedByCapk] = "true"
+			})
+
+			It("Should skip uncordon without error and keep annotation", func() {
+				externalMachine, err := defaultTestMachine(machineContext, namespace, fakeClient, fakeVMCommandExecutor, []byte(sshKey))
+				Expect(err).NotTo(HaveOccurred())
+
+				requeueDuration, err := externalMachine.DrainNodeIfNeeded(nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(requeueDuration).Should(BeZero())
+
+				By("The node-cordoned annotation should still be present")
+				kvMachine := &v1alpha1.KubevirtMachine{}
+				err = fakeClient.Get(gocontext.Background(), client.ObjectKey{Namespace: kubevirtMachine.Namespace, Name: kubevirtMachine.Name}, kvMachine)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(kvMachine.Annotations).To(HaveKey(v1alpha1.NodeCordonedByCapk))
+			})
+		})
+
+		When("Cordon annotation present but workload cluster client fails", func() {
+			BeforeEach(func() {
+				virtualMachineInstance.Spec.EvictionStrategy = nil
+				virtualMachineInstance.Status.EvacuationNodeName = ""
+				kubevirtMachine.Annotations[v1alpha1.NodeCordonedByCapk] = "true"
+			})
+
+			It("Should requeue with 100ms on client error", func() {
+				fakeErr := errors.New("fake error: can't create workload cluster client")
+				wlCluster.EXPECT().GenerateWorkloadClusterK8sClient(gomock.Any()).Return(nil, fakeErr).Times(1)
+
+				externalMachine, err := defaultTestMachine(machineContext, namespace, fakeClient, fakeVMCommandExecutor, []byte(sshKey))
+				Expect(err).NotTo(HaveOccurred())
+
+				requeueDuration, err := externalMachine.DrainNodeIfNeeded(wlCluster)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(requeueDuration).To(Equal(100 * time.Millisecond))
+
+				By("The node-cordoned annotation should still be present")
+				kvMachine := &v1alpha1.KubevirtMachine{}
+				err = fakeClient.Get(gocontext.Background(), client.ObjectKey{Namespace: kubevirtMachine.Namespace, Name: kubevirtMachine.Name}, kvMachine)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(kvMachine.Annotations).To(HaveKey(v1alpha1.NodeCordonedByCapk))
+			})
+		})
+
+		When("Cordon annotation present but node get fails with non-NotFound error", func() {
+			BeforeEach(func() {
+				virtualMachineInstance.Spec.EvictionStrategy = nil
+				virtualMachineInstance.Status.EvacuationNodeName = ""
+				kubevirtMachine.Annotations[v1alpha1.NodeCordonedByCapk] = "true"
+			})
+
+			It("Should requeue with 100ms on node get error", func() {
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: kubevirtMachineName,
+					},
+				}
+
+				Expect(k8sfake.AddToScheme(setupRemoteScheme())).ToNot(HaveOccurred())
+				cl := k8sfake.NewClientset(node)
+
+				fakeErr := errors.New("fake error: can't get node")
+				cl.PrependReactor("get", "nodes", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, nil, fakeErr
+				})
+
+				wlCluster.EXPECT().GenerateWorkloadClusterK8sClient(gomock.Any()).Return(cl, nil).Times(1)
+
+				externalMachine, err := defaultTestMachine(machineContext, namespace, fakeClient, fakeVMCommandExecutor, []byte(sshKey))
+				Expect(err).NotTo(HaveOccurred())
+
+				requeueDuration, err := externalMachine.DrainNodeIfNeeded(wlCluster)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(requeueDuration).To(Equal(100 * time.Millisecond))
+
+				By("The node-cordoned annotation should still be present")
+				kvMachine := &v1alpha1.KubevirtMachine{}
+				err = fakeClient.Get(gocontext.Background(), client.ObjectKey{Namespace: kubevirtMachine.Namespace, Name: kubevirtMachine.Name}, kvMachine)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(kvMachine.Annotations).To(HaveKey(v1alpha1.NodeCordonedByCapk))
 			})
 		})
 	})


### PR DESCRIPTION
When CAPK handles a VMI eviction (`evictionStrategy=External`), it cordons and drains the guest node before deleting the VMI. After KubeVirt recreates the VMI on another host, the guest node reconnects but stays cordoned (`spec.unschedulable=true`) indefinitely because nothing uncordons it.

Track the cordon with a new annotation (`capk.cluster.x-k8s.io/node-cordoned`) on the `KubevirtMachine`, and uncordon the guest node in `DrainNodeIfNeeded` when no eviction is in progress but the annotation is present.


<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix guest node remaining cordoned after VMI eviction and restart
```
