### PR TITLE
Declare cluster.x-k8s.io/v1beta2 contract support in CRD labels

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -5,6 +5,7 @@ commonLabels:
   cluster.x-k8s.io/v1alpha3: v1alpha1
   cluster.x-k8s.io/v1alpha4: v1alpha1
   cluster.x-k8s.io/v1beta1: v1alpha1
+  cluster.x-k8s.io/v1beta2: v1alpha1
 
 # This kustomization.yaml is not intended to be run by itself,
 # since it depends on service name and namespace that are out of this kustomize package.


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the `cluster.x-k8s.io/v1beta2` contract label to CAPK's infrastructure CRDs
(KubevirtCluster, KubevirtClusterTemplate, KubevirtMachine, KubevirtMachineTemplate) via
`config/crd/kustomization.yaml`, so that core Cluster API v1.13+ can recognize CAPK as
v1beta2-contract-compatible.

This is a metadata-only change, the same mechanism used to originally add the `v1beta1` label:


commonLabels: ... cluster.x-k8s.io/v1beta1: v1alpha1

• cluster.x-k8s.io/v1beta2: v1alpha1


No Go dependency bump, no controller code changes, and no change to the CRD's served/storage
API version (`v1alpha1` remains the only served version). CAPK continues to watch and reconcile
`v1alpha1` resources exactly as before.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #390

**Special notes for your reviewer**:

This is intentionally much narrower than the earlier v1beta2 effort in #328, which bumped the
`cluster-api` Go module to v1.11 and updated CAPK's own condition types — that change broke
users still on CAPI v1.10 and was reverted in #361/#363.

This PR does not touch CAPK's dependencies or code at all; it only adds a contract label so that
core CAPI's `Cluster`/topology controllers can resolve `infrastructureRef`/`controlPlaneRef`
lookups when a `Cluster` is created with `apiVersion: cluster.x-k8s.io/v1beta2`. Because the
underlying CRD API version is unchanged, this should be safe for users on any CAPI version,
including those still on v1beta1/v1.10.

Verified locally:
- `kustomize build config/crd` shows `cluster.x-k8s.io/v1beta2: v1alpha1` on all 4 CRDs.
- Applied the patched CRDs to a live management cluster running CAPI v1.13.4 + this CAPK
  controller (v0.11.2, unmodified). Created a scratch `Cluster` (`apiVersion:
  cluster.x-k8s.io/v1beta2`) referencing `KubevirtCluster` via the new `infrastructureRef.apiGroup`
  style. The core CAPI controller correctly resolved the contract, set
  `ownerReferences[].apiVersion: cluster.x-k8s.io/v1beta2` on the `KubevirtCluster`, and began
  reconciling normally (no "contract not found"/CRD lookup errors). `capk-controller-manager`
  remained healthy and unaffected throughout.

**Release notes**:
```release-note
Add `cluster.x-k8s.io/v1beta2` contract label to CAPK infrastructure CRDs, enabling Cluster API
v1beta2 Cluster resources to reference KubevirtCluster/KubevirtMachine as infrastructure providers.
