### PR TITLE
OCPBUGS-98217: Attempt live migration before drain+delete for migratable VMIs

### DIFF
--- a/api/v1alpha1/kubevirtcluster_types.go
+++ b/api/v1alpha1/kubevirtcluster_types.go
@@ -44,6 +44,13 @@ const ( // annotations
 	// after the VMI is recreated on a different host.
 	NodeCordonedByCapk       = "capk.cluster.x-k8s.io/node-cordoned"
 	NodeCordonedByCapkEscape = "capk.cluster.x-k8s.io~1node-cordoned"
+
+	// VmiMigrationSubmitted is set on KubevirtMachine when CAPK creates a
+	// VirtualMachineInstanceMigration for a migratable VMI. It prevents
+	// duplicate migration creates and decouples the grace period timer from
+	// migration submission -- the timer only starts when the migration is
+	// actively in progress.
+	VmiMigrationSubmitted = "capk.cluster.x-k8s.io/migration-submitted"
 )
 
 // KubevirtClusterSpec defines the desired state of KubevirtCluster.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -83,6 +83,12 @@ rules:
 - apiGroups:
   - kubevirt.io
   resources:
+  - virtualmachineinstancemigrations
+  verbs:
+  - create
+- apiGroups:
+  - kubevirt.io
+  resources:
   - virtualmachineinstances
   verbs:
   - delete

--- a/controllers/kubevirtmachine_controller.go
+++ b/controllers/kubevirtmachine_controller.go
@@ -67,6 +67,7 @@ type KubevirtMachineReconciler struct {
 // +kubebuilder:rbac:groups="",resources=secrets;,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=kubevirt.io,resources=virtualmachines;,verbs=get;create;update;patch;delete
 // +kubebuilder:rbac:groups=kubevirt.io,resources=virtualmachineinstances;,verbs=get;delete
+// +kubebuilder:rbac:groups=kubevirt.io,resources=virtualmachineinstancemigrations;,verbs=create
 // +kubebuilder:rbac:groups=cdi.kubevirt.io,resources=datavolumes;,verbs=get;list;watch
 
 // Reconcile handles KubevirtMachine events.

--- a/pkg/kubevirt/machine.go
+++ b/pkg/kubevirt/machine.go
@@ -431,10 +431,8 @@ func (m *Machine) Delete() error {
 
 func (m *Machine) DrainNodeIfNeeded(wrkldClstr workloadcluster.WorkloadCluster) (time.Duration, error) {
 	if m.vmiInstance == nil || !m.shouldGracefulDeleteVMI() {
-		if _, anntExists := m.machineContext.KubevirtMachine.Annotations[infrav1.VmiDeletionGraceTime]; anntExists {
-			if err := m.removeGracePeriodAnnotation(); err != nil {
-				return 100 * time.Millisecond, err
-			}
+		if err := m.cleanupMigrationAnnotations(); err != nil {
+			return 100 * time.Millisecond, err
 		}
 
 		// Only uncordon when the VMI is back and not being deleted. If the VMI
@@ -448,6 +446,30 @@ func (m *Machine) DrainNodeIfNeeded(wrkldClstr workloadcluster.WorkloadCluster) 
 		}
 
 		return 0, nil
+	}
+
+	// For migratable VMIs, attempt live migration before the disruptive
+	// drain+delete path. If migration succeeds, the guest node is untouched.
+	if m.vmiInstance.IsMigratable() {
+		migrated, requeueAfter, err := m.tryMigrateVMI()
+		if err != nil {
+			return 0, err
+		}
+		if migrated {
+			if err := m.cleanupMigrationAnnotations(); err != nil {
+				return 100 * time.Millisecond, err
+			}
+			return 0, nil
+		}
+		if requeueAfter > 0 {
+			return requeueAfter, nil
+		}
+		// Migration failed or timed out -- clean up migration annotations
+		// and reset the grace period so the drain+delete fallback gets a
+		// fresh timeout window.
+		if err := m.cleanupMigrationAnnotations(); err != nil {
+			return 100 * time.Millisecond, err
+		}
 	}
 
 	exceeded, err := m.drainGracePeriodExceeded()
@@ -484,6 +506,8 @@ func (m *Machine) DrainNodeIfNeeded(wrkldClstr workloadcluster.WorkloadCluster) 
 
 const removeGracePeriodAnnotationPatch = `[{"op": "remove", "path": "/metadata/annotations/` + infrav1.VmiDeletionGraceTimeEscape + `"}]`
 
+const cleanupMigrationAnnotationsPatch = `{"metadata":{"annotations":{"` + infrav1.VmiMigrationSubmitted + `": null, "` + infrav1.VmiDeletionGraceTime + `": null}}}`
+
 func (m *Machine) removeGracePeriodAnnotation() error {
 	patch := client.RawPatch(types.JSONPatchType, []byte(removeGracePeriodAnnotationPatch))
 
@@ -491,6 +515,24 @@ func (m *Machine) removeGracePeriodAnnotation() error {
 		return fmt.Errorf("failed to remove the %s annotation to the KubeVirtMachine %s; %w", infrav1.VmiDeletionGraceTime, m.machineContext.KubevirtMachine.Name, err)
 	}
 
+	return nil
+}
+
+// cleanupMigrationAnnotations removes both the migration-submitted marker and
+// the grace period annotation in a single merge patch. Setting a key to null
+// in a merge patch removes it; if the key does not exist, it is a no-op.
+func (m *Machine) cleanupMigrationAnnotations() error {
+	annotations := m.machineContext.KubevirtMachine.Annotations
+	_, hasMigration := annotations[infrav1.VmiMigrationSubmitted]
+	_, hasGrace := annotations[infrav1.VmiDeletionGraceTime]
+	if !hasMigration && !hasGrace {
+		return nil
+	}
+
+	patchRequest := client.RawPatch(types.MergePatchType, []byte(cleanupMigrationAnnotationsPatch))
+	if err := m.client.Patch(m.machineContext, m.machineContext.KubevirtMachine, patchRequest); err != nil {
+		return fmt.Errorf("failed to clean up migration annotations on KubevirtMachine %s: %w", m.machineContext.KubevirtMachine.Name, err)
+	}
 	return nil
 }
 
@@ -558,6 +600,97 @@ func (m *Machine) uncordonNodeIfNeeded(wrkldClstr workloadcluster.WorkloadCluste
 	}
 
 	return m.removeNodeCordonedAnnotation()
+}
+
+// tryMigrateVMI attempts to live-migrate a migratable VMI instead of the
+// disruptive drain+delete path. It returns:
+//   - migrated=true when the VMI has already moved to a different host
+//   - requeueAfter>0 when a migration is in progress or was just created
+//   - both zero when migration failed/timed out (caller should fall through to drain+delete)
+//
+// The grace period timer is deliberately deferred until the migration is
+// actively in progress (MigrationState is set). This ensures that on dense
+// nodes where KubeVirt serializes outbound migrations (1 at a time), VMs
+// waiting in the migration queue don't burn through their timeout window
+// before their migration even starts.
+func (m *Machine) tryMigrateVMI() (migrated bool, requeueAfter time.Duration, err error) {
+	// If the VMI is already on a different node than the evacuation source,
+	// migration has succeeded -- no guest disruption needed.
+	if m.vmiInstance.Status.NodeName != m.vmiInstance.Status.EvacuationNodeName {
+		m.machineContext.Logger.Info("VMI successfully migrated, skipping drain+delete",
+			"from", m.vmiInstance.Status.EvacuationNodeName,
+			"to", m.vmiInstance.Status.NodeName)
+		return true, 0, nil
+	}
+
+	if ms := m.vmiInstance.Status.MigrationState; ms != nil {
+		if ms.Failed {
+			m.machineContext.Logger.Info("VMI migration failed, falling back to drain+delete",
+				"vmi", m.vmiInstance.Name)
+			return false, 0, nil
+		}
+		if !ms.Completed {
+			// Migration is actively in progress -- the grace period timer
+			// starts here (not when the migration CR was first created).
+			exceeded, err := m.drainGracePeriodExceeded()
+			if err != nil {
+				return false, 0, err
+			}
+			if exceeded {
+				m.machineContext.Logger.Info("Migration timeout exceeded while migration in progress, falling back to drain+delete",
+					"vmi", m.vmiInstance.Name)
+				return false, 0, nil
+			}
+			m.machineContext.Logger.Info("VMI migration in progress, waiting",
+				"vmi", m.vmiInstance.Name)
+			return false, 10 * time.Second, nil
+		}
+	}
+
+	// No active migration. Check if we've already submitted a migration CR
+	// on a previous reconcile (waiting for KubeVirt to pick it up).
+	if _, exists := m.machineContext.KubevirtMachine.Annotations[infrav1.VmiMigrationSubmitted]; exists {
+		m.machineContext.Logger.Info("Migration already submitted, waiting for KubeVirt to start it",
+			"vmi", m.vmiInstance.Name)
+		return false, 10 * time.Second, nil
+	}
+
+	// First reconcile for this evacuation -- create a migration CR.
+	priority := kubevirtv1.PrioritySystemCritical
+	migration := &kubevirtv1.VirtualMachineInstanceMigration{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: m.vmiInstance.Name + "-migration-",
+			Namespace:    m.vmiInstance.Namespace,
+		},
+		Spec: kubevirtv1.VirtualMachineInstanceMigrationSpec{
+			VMIName:  m.vmiInstance.Name,
+			Priority: &priority,
+		},
+	}
+
+	if err := m.client.Create(m.machineContext, migration); err != nil {
+		m.machineContext.Logger.Error(err, "Failed to create VirtualMachineInstanceMigration, falling back to drain+delete",
+			"vmi", m.vmiInstance.Name)
+		return false, 0, nil
+	}
+
+	if err := m.setMigrationSubmittedAnnotation(); err != nil {
+		return false, 0, err
+	}
+
+	m.machineContext.Logger.Info("Created VirtualMachineInstanceMigration for migratable VMI",
+		"migration", migration.Name, "vmi", m.vmiInstance.Name)
+
+	return false, 10 * time.Second, nil
+}
+
+func (m *Machine) setMigrationSubmittedAnnotation() error {
+	patch := fmt.Sprintf(`{"metadata":{"annotations":{"%s": "true"}}}`, infrav1.VmiMigrationSubmitted)
+	patchRequest := client.RawPatch(types.MergePatchType, []byte(patch))
+	if err := m.client.Patch(m.machineContext, m.machineContext.KubevirtMachine, patchRequest); err != nil {
+		return fmt.Errorf("failed to set the %s annotation on KubevirtMachine %s: %w", infrav1.VmiMigrationSubmitted, m.machineContext.KubevirtMachine.Name, err)
+	}
+	return nil
 }
 
 func (m *Machine) shouldGracefulDeleteVMI() bool {

--- a/pkg/kubevirt/machine_test.go
+++ b/pkg/kubevirt/machine_test.go
@@ -604,6 +604,233 @@ var _ = Describe("With KubeVirt VM running", func() {
 			})
 		})
 
+		Context("migration-first eviction for migratable VMIs", func() {
+			BeforeEach(func() {
+				virtualMachineInstance.Status.NodeName = hostNodeName
+				virtualMachineInstance.Status.Conditions = append(
+					virtualMachineInstance.Status.Conditions,
+					kubevirtv1.VirtualMachineInstanceCondition{
+						Type:   kubevirtv1.VirtualMachineInstanceIsMigratable,
+						Status: corev1.ConditionTrue,
+					},
+				)
+			})
+
+			When("no migration exists yet", func() {
+				It("Should create a VirtualMachineInstanceMigration and requeue", func() {
+					wlCluster.EXPECT().GenerateWorkloadClusterK8sClient(gomock.Any()).Times(0)
+
+					externalMachine, err := defaultTestMachine(machineContext, namespace, fakeClient, fakeVMCommandExecutor, []byte(sshKey))
+					Expect(err).NotTo(HaveOccurred())
+
+					requeueDuration, err := externalMachine.DrainNodeIfNeeded(wlCluster)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(requeueDuration).To(Equal(10 * time.Second))
+
+					By("VMI should still exist (not drained+deleted)")
+					vmi := &kubevirtv1.VirtualMachineInstance{}
+					err = fakeClient.Get(gocontext.Background(), client.ObjectKey{Namespace: virtualMachineInstance.Namespace, Name: virtualMachineInstance.Name}, vmi)
+					Expect(err).ToNot(HaveOccurred())
+
+					By("A VirtualMachineInstanceMigration should have been created")
+					migrationList := &kubevirtv1.VirtualMachineInstanceMigrationList{}
+					err = fakeClient.List(gocontext.Background(), migrationList, client.InNamespace(virtualMachineInstance.Namespace))
+					Expect(err).ToNot(HaveOccurred())
+					Expect(migrationList.Items).To(HaveLen(1))
+					Expect(migrationList.Items[0].Spec.VMIName).To(Equal(virtualMachineInstance.Name))
+
+					By("Migration should have SystemCritical priority")
+					Expect(migrationList.Items[0].Spec.Priority).ToNot(BeNil())
+					Expect(*migrationList.Items[0].Spec.Priority).To(Equal(kubevirtv1.PrioritySystemCritical))
+
+					By("Migration-submitted annotation should be set, but NOT the grace period timer")
+					updatedKM := &v1alpha1.KubevirtMachine{}
+					err = fakeClient.Get(gocontext.Background(), client.ObjectKeyFromObject(kubevirtMachine), updatedKM)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(updatedKM.Annotations).To(HaveKey(v1alpha1.VmiMigrationSubmitted))
+					Expect(updatedKM.Annotations).ToNot(HaveKey(v1alpha1.VmiDeletionGraceTime))
+				})
+			})
+
+			When("migration already submitted but not yet started by KubeVirt", func() {
+				BeforeEach(func() {
+					kubevirtMachine.Annotations[v1alpha1.VmiMigrationSubmitted] = "true"
+				})
+
+				It("Should requeue without creating a duplicate migration", func() {
+					wlCluster.EXPECT().GenerateWorkloadClusterK8sClient(gomock.Any()).Times(0)
+
+					externalMachine, err := defaultTestMachine(machineContext, namespace, fakeClient, fakeVMCommandExecutor, []byte(sshKey))
+					Expect(err).NotTo(HaveOccurred())
+
+					requeueDuration, err := externalMachine.DrainNodeIfNeeded(wlCluster)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(requeueDuration).To(Equal(10 * time.Second))
+
+					By("No new VirtualMachineInstanceMigration should have been created")
+					migrationList := &kubevirtv1.VirtualMachineInstanceMigrationList{}
+					err = fakeClient.List(gocontext.Background(), migrationList, client.InNamespace(virtualMachineInstance.Namespace))
+					Expect(err).ToNot(HaveOccurred())
+					Expect(migrationList.Items).To(BeEmpty())
+
+					By("Grace period timer should NOT be set yet")
+					updatedKM := &v1alpha1.KubevirtMachine{}
+					err = fakeClient.Get(gocontext.Background(), client.ObjectKeyFromObject(kubevirtMachine), updatedKM)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(updatedKM.Annotations).ToNot(HaveKey(v1alpha1.VmiDeletionGraceTime))
+				})
+			})
+
+			When("migration is in progress", func() {
+				BeforeEach(func() {
+					virtualMachineInstance.Status.MigrationState = &kubevirtv1.VirtualMachineInstanceMigrationState{
+						StartTimestamp: nowTimestamp(),
+					}
+					graceTime := time.Now().UTC().Add(5 * time.Minute).Format(time.RFC3339)
+					kubevirtMachine.Annotations[v1alpha1.VmiDeletionGraceTime] = graceTime
+				})
+
+				It("Should requeue and wait for migration", func() {
+					wlCluster.EXPECT().GenerateWorkloadClusterK8sClient(gomock.Any()).Times(0)
+
+					externalMachine, err := defaultTestMachine(machineContext, namespace, fakeClient, fakeVMCommandExecutor, []byte(sshKey))
+					Expect(err).NotTo(HaveOccurred())
+
+					requeueDuration, err := externalMachine.DrainNodeIfNeeded(wlCluster)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(requeueDuration).To(Equal(10 * time.Second))
+
+					By("VMI should still exist")
+					vmi := &kubevirtv1.VirtualMachineInstance{}
+					err = fakeClient.Get(gocontext.Background(), client.ObjectKey{Namespace: virtualMachineInstance.Namespace, Name: virtualMachineInstance.Name}, vmi)
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+
+			When("migration succeeded (VMI on different node)", func() {
+				BeforeEach(func() {
+					virtualMachineInstance.Status.NodeName = "target-node-2"
+					virtualMachineInstance.Status.MigrationState = &kubevirtv1.VirtualMachineInstanceMigrationState{
+						Completed:  true,
+						SourceNode: hostNodeName,
+						TargetNode: "target-node-2",
+					}
+				})
+
+				It("Should skip drain+delete and return success", func() {
+					wlCluster.EXPECT().GenerateWorkloadClusterK8sClient(gomock.Any()).Times(0)
+
+					externalMachine, err := defaultTestMachine(machineContext, namespace, fakeClient, fakeVMCommandExecutor, []byte(sshKey))
+					Expect(err).NotTo(HaveOccurred())
+
+					requeueDuration, err := externalMachine.DrainNodeIfNeeded(wlCluster)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(requeueDuration).Should(BeZero())
+
+					By("VMI should still exist (not deleted)")
+					vmi := &kubevirtv1.VirtualMachineInstance{}
+					err = fakeClient.Get(gocontext.Background(), client.ObjectKey{Namespace: virtualMachineInstance.Namespace, Name: virtualMachineInstance.Name}, vmi)
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+
+			When("migration failed", func() {
+				BeforeEach(func() {
+					virtualMachineInstance.Status.MigrationState = &kubevirtv1.VirtualMachineInstanceMigrationState{
+						Failed: true,
+					}
+				})
+
+				It("Should fall through to drain+delete", func() {
+					node := &corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: kubevirtMachineName,
+						},
+					}
+					Expect(k8sfake.AddToScheme(setupRemoteScheme())).ToNot(HaveOccurred())
+					cl := k8sfake.NewClientset(node)
+					wlCluster.EXPECT().GenerateWorkloadClusterK8sClient(gomock.Any()).Return(cl, nil).Times(1)
+
+					externalMachine, err := defaultTestMachine(machineContext, namespace, fakeClient, fakeVMCommandExecutor, []byte(sshKey))
+					Expect(err).NotTo(HaveOccurred())
+
+					requeueDuration, err := externalMachine.DrainNodeIfNeeded(wlCluster)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(requeueDuration).To(Equal(10 * time.Second))
+
+					By("VMI should be deleted (drain+delete fallback)")
+					vmi := &kubevirtv1.VirtualMachineInstance{}
+					err = fakeClient.Get(gocontext.Background(), client.ObjectKey{Namespace: virtualMachineInstance.Namespace, Name: virtualMachineInstance.Name}, vmi)
+					Expect(err).To(HaveOccurred())
+					Expect(apierrors.IsNotFound(err)).To(BeTrue())
+				})
+			})
+
+			When("migration timed out (grace period exceeded during migration)", func() {
+				BeforeEach(func() {
+					virtualMachineInstance.Status.MigrationState = &kubevirtv1.VirtualMachineInstanceMigrationState{
+						StartTimestamp: nowTimestamp(),
+					}
+					graceTime := time.Now().UTC().Add(-1 * time.Minute).Format(time.RFC3339)
+					kubevirtMachine.Annotations[v1alpha1.VmiDeletionGraceTime] = graceTime
+				})
+
+				It("Should fall through to drain+delete", func() {
+					node := &corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: kubevirtMachineName,
+						},
+					}
+					Expect(k8sfake.AddToScheme(setupRemoteScheme())).ToNot(HaveOccurred())
+					cl := k8sfake.NewClientset(node)
+					wlCluster.EXPECT().GenerateWorkloadClusterK8sClient(gomock.Any()).Return(cl, nil).Times(1)
+
+					externalMachine, err := defaultTestMachine(machineContext, namespace, fakeClient, fakeVMCommandExecutor, []byte(sshKey))
+					Expect(err).NotTo(HaveOccurred())
+
+					requeueDuration, err := externalMachine.DrainNodeIfNeeded(wlCluster)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(requeueDuration).To(Equal(10 * time.Second))
+
+					By("VMI should be deleted (drain+delete fallback)")
+					vmi := &kubevirtv1.VirtualMachineInstance{}
+					err = fakeClient.Get(gocontext.Background(), client.ObjectKey{Namespace: virtualMachineInstance.Namespace, Name: virtualMachineInstance.Name}, vmi)
+					Expect(err).To(HaveOccurred())
+					Expect(apierrors.IsNotFound(err)).To(BeTrue())
+				})
+			})
+
+			When("migration creation fails", func() {
+				It("Should fall through to drain+delete gracefully", func() {
+					node := &corev1.Node{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: kubevirtMachineName,
+						},
+					}
+					Expect(k8sfake.AddToScheme(setupRemoteScheme())).ToNot(HaveOccurred())
+					cl := k8sfake.NewClientset(node)
+					wlCluster.EXPECT().GenerateWorkloadClusterK8sClient(gomock.Any()).Return(cl, nil).Times(1)
+
+					externalMachine, err := defaultTestMachine(machineContext, namespace, fakeClient, fakeVMCommandExecutor, []byte(sshKey))
+					Expect(err).NotTo(HaveOccurred())
+
+					By("Inject a create failure for migrations")
+					origClient := externalMachine.client
+					externalMachine.client = &migrationFailClient{Client: origClient}
+
+					requeueDuration, err := externalMachine.DrainNodeIfNeeded(wlCluster)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(requeueDuration).To(Equal(10 * time.Second))
+
+					By("VMI should be deleted (drain+delete fallback)")
+					vmi := &kubevirtv1.VirtualMachineInstance{}
+					err = origClient.Get(gocontext.Background(), client.ObjectKey{Namespace: virtualMachineInstance.Namespace, Name: virtualMachineInstance.Name}, vmi)
+					Expect(err).To(HaveOccurred())
+					Expect(apierrors.IsNotFound(err)).To(BeTrue())
+				})
+			})
+		})
+
 		When("VMI was recreated after eviction and guest node is still cordoned", func() {
 			BeforeEach(func() {
 				virtualMachineInstance.Spec.EvictionStrategy = nil
@@ -1309,4 +1536,22 @@ func setupRemoteScheme() *runtime.Scheme {
 		panic(err)
 	}
 	return s
+}
+
+func nowTimestamp() *metav1.Time {
+	t := metav1.Now()
+	return &t
+}
+
+// migrationFailClient wraps a controller-runtime client and fails Create
+// calls for VirtualMachineInstanceMigration objects.
+type migrationFailClient struct {
+	client.Client
+}
+
+func (c *migrationFailClient) Create(ctx gocontext.Context, obj client.Object, opts ...client.CreateOption) error {
+	if _, ok := obj.(*kubevirtv1.VirtualMachineInstanceMigration); ok {
+		return fmt.Errorf("fake error: can't create migration")
+	}
+	return c.Client.Create(ctx, obj, opts...)
 }


### PR DESCRIPTION
When a migratable VMI with `EvictionStrategy=External` is marked for eviction, CAPK now creates a `VirtualMachineInstanceMigration` to attempt zero-disruption live migration before falling back to the disruptive drain+delete path.

The migration lifecycle is handled by a new `tryMigrateVMI()` function:
- Detects successful migration via `NodeName != EvacuationNodeName`
- Waits for in-progress migrations within the existing 10-minute grace period
- Falls back to drain+delete on migration failure or timeout, resetting the grace period so the fallback gets a fresh timeout window
- Falls back gracefully if migration creation fails

Non-migratable VMIs continue through the existing drain+delete path unchanged.


<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes # https://redhat.atlassian.net/browse/OCPBUGS-98217

**Special notes for your reviewer**:

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Attempt live migration before drain+delete for migratable VMIs
```
