### PR TITLE
Fix nil map panics and set CAPI v1beta2 initialization status

### DIFF
--- a/controllers/kubevirtcluster_controller.go
+++ b/controllers/kubevirtcluster_controller.go
@@ -248,6 +248,11 @@ func (r *KubevirtClusterReconciler) reconcileNormal(ctx *context.ClusterContext,
 
 	// Mark the KubevirtCluster ready
 	ctx.KubevirtCluster.Status.Ready = true
+	if ctx.KubevirtCluster.Status.Initialization == nil {
+		ctx.KubevirtCluster.Status.Initialization = &infrav1.KubevirtClusterInitializationStatus{}
+	}
+	provisioned := true
+	ctx.KubevirtCluster.Status.Initialization.Provisioned = &provisioned
 
 	return ctrl.Result{}, nil
 }

--- a/controllers/kubevirtmachine_controller.go
+++ b/controllers/kubevirtmachine_controller.go
@@ -422,6 +422,11 @@ func (r *KubevirtMachineReconciler) reconcileNormal(ctx *context.MachineContext)
 	// Ready should reflect if the VMI is ready or not
 	if externalMachine.IsReady() {
 		ctx.KubevirtMachine.Status.Ready = true
+		if ctx.KubevirtMachine.Status.Initialization == nil {
+			ctx.KubevirtMachine.Status.Initialization = &infrav1.KubevirtMachineInitializationStatus{}
+		}
+		provisioned := true
+		ctx.KubevirtMachine.Status.Initialization.Provisioned = &provisioned
 	} else {
 		ctx.KubevirtMachine.Status.Ready = false
 	}

--- a/pkg/kubevirt/machine.go
+++ b/pkg/kubevirt/machine.go
@@ -187,6 +187,9 @@ func (m *Machine) Create(ctx gocontext.Context) error {
 		if virtualMachine.Labels == nil {
 			virtualMachine.Labels = map[string]string{}
 		}
+		if virtualMachine.Annotations == nil {
+			virtualMachine.Annotations = map[string]string{}
+		}
 		if virtualMachine.Spec.Template.ObjectMeta.Labels == nil {
 			virtualMachine.Spec.Template.ObjectMeta.Labels = map[string]string{}
 		}

--- a/pkg/kubevirt/utils.go
+++ b/pkg/kubevirt/utils.go
@@ -93,6 +93,9 @@ func newVirtualMachineFromKubevirtMachine(ctx *context.MachineContext, namespace
 	if ctx.KubevirtMachine.Spec.VirtualMachineTemplate.ObjectMeta.Annotations != nil {
 		virtualMachine.Annotations = mapCopy(ctx.KubevirtMachine.Spec.VirtualMachineTemplate.ObjectMeta.Annotations)
 	}
+	if virtualMachine.Annotations == nil {
+		virtualMachine.Annotations = map[string]string{}
+	}
 
 	virtualMachine.Labels["kubevirt.io/vm"] = ctx.KubevirtMachine.Name
 	virtualMachine.Labels["name"] = ctx.KubevirtMachine.Name
@@ -155,7 +158,7 @@ func buildVirtualMachineInstanceTemplate(ctx *context.MachineContext) *kubevirtv
 		Name: cloudInitVolumeName,
 		DiskDevice: kubevirtv1.DiskDevice{
 			Disk: &kubevirtv1.DiskTarget{
-				Bus: "virtio",
+				Bus: kubevirtv1.DiskBusVirtio,
 			},
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix nil map assignment panics when creating VMs from templates without annotations. The `Create() mutateFn` and `newVirtualMachineFromKubevirtMachine` both write to the annotations map without checking if it's nil.

Also set `status.initialization.provisioned=true` in both the cluster and machine controllers when the resource becomes Ready. This field is required by the CAPI v1beta2 Machine controller to proceed with `providerID` propagation.

Additionally, use the typed `kubevirtv1.DiskBusVirtio` constant instead of the hardcoded `"virtio"` string for the cloud-init disk bus.


<!-- Thanks for sending a pull request! -->



**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix nil map panics and set CAPI v1beta2 initialization status
```
