### PR TITLE
Enforce same-namespace constraint on infraClusterSecretRef and tighten RBAC

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -22,7 +22,6 @@ rules:
   - delete
   - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -27,3 +27,47 @@ webhooks:
     resources:
     - kubevirtmachinetemplates
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1alpha1-kubevirtcluster
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.kubevirtcluster.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kubevirtclusters
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1alpha1-kubevirtmachine
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.kubevirtmachine.infrastructure.cluster.x-k8s.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - kubevirtmachines
+  sideEffects: None

--- a/controllers/kubevirtcluster_controller.go
+++ b/controllers/kubevirtcluster_controller.go
@@ -70,7 +70,7 @@ func GetLoadBalancerNamespace(kc *infrav1.KubevirtCluster, infraClusterNamespace
 
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=kubevirtclusters,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=kubevirtclusters/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups="",resources=services;,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=services;,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups="",resources=serviceaccounts;configmaps,verbs=delete;list
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=delete;list
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=delete;list

--- a/controllers/kubevirtmachine_controller.go
+++ b/controllers/kubevirtmachine_controller.go
@@ -64,7 +64,7 @@ type KubevirtMachineReconciler struct {
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=kubevirtmachines,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=kubevirtmachines/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters;machines,verbs=get;list;watch
-// +kubebuilder:rbac:groups="",resources=secrets;,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=secrets;,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups=kubevirt.io,resources=virtualmachines;,verbs=get;create;update;patch;delete
 // +kubebuilder:rbac:groups=kubevirt.io,resources=virtualmachineinstances;,verbs=get;delete
 // +kubebuilder:rbac:groups=kubevirt.io,resources=virtualmachineinstancemigrations;,verbs=create

--- a/main.go
+++ b/main.go
@@ -228,9 +228,11 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 		os.Exit(1)
 	}
 
+	controllerNS := resolveControllerNamespace()
+
 	if err := (&controllers.KubevirtMachineReconciler{
 		Client:          mgr.GetClient(),
-		InfraCluster:    infracluster.New(mgr.GetClient(), noCachedClient),
+		InfraCluster:    infracluster.New(mgr.GetClient(), noCachedClient, controllerNS),
 		WorkloadCluster: workloadcluster.New(mgr.GetClient()),
 		MachineFactory:  kubevirt.DefaultMachineFactory{},
 	}).SetupWithManager(ctx, mgr, controller.Options{
@@ -243,7 +245,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 	if err := (&controllers.KubevirtClusterReconciler{
 		Client:       mgr.GetClient(),
 		APIReader:    mgr.GetAPIReader(),
-		InfraCluster: infracluster.New(mgr.GetClient(), noCachedClient),
+		InfraCluster: infracluster.New(mgr.GetClient(), noCachedClient, controllerNS),
 		Log:          ctrl.Log.WithName("controllers").WithName("KubevirtCluster"),
 	}).SetupWithManager(ctx, mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "KubevirtCluster")
@@ -261,8 +263,19 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 }
 
 func setupWebhooks(mgr ctrl.Manager) {
-	if err := webhookhandler.SetupWebhookWithManager(mgr); err != nil {
+	controllerNS := resolveControllerNamespace()
+	if err := webhookhandler.SetupWebhookWithManager(mgr, controllerNS); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "KubevirtMachineTemplate")
 		os.Exit(1)
 	}
+}
+
+func resolveControllerNamespace() string {
+	if ns := os.Getenv("POD_NAMESPACE"); ns != "" {
+		return ns
+	}
+	if data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
+		return string(data)
+	}
+	return ""
 }

--- a/pkg/infracluster/infracluster.go
+++ b/pkg/infracluster/infracluster.go
@@ -20,23 +20,25 @@ type InfraCluster interface {
 type ClientFactoryFunc func(config *rest.Config, options k8sclient.Options) (k8sclient.Client, error)
 
 // New creates new InfraCluster instance
-func New(client k8sclient.Client, noCachedClient k8sclient.Client) InfraCluster {
-	return NewWithFactory(client, noCachedClient, k8sclient.New)
+func New(client k8sclient.Client, noCachedClient k8sclient.Client, controllerNamespace string) InfraCluster {
+	return NewWithFactory(client, noCachedClient, k8sclient.New, controllerNamespace)
 }
 
 // NewWithFactory creates new InfraCluster instance that uses the provided client factory function.
-func NewWithFactory(client k8sclient.Client, noCachedClient k8sclient.Client, factory ClientFactoryFunc) InfraCluster {
+func NewWithFactory(client k8sclient.Client, noCachedClient k8sclient.Client, factory ClientFactoryFunc, controllerNamespace string) InfraCluster {
 	return &infraCluster{
-		Client:         client,
-		NoCachedClient: noCachedClient,
-		ClientFactory:  factory,
+		Client:              client,
+		NoCachedClient:      noCachedClient,
+		ClientFactory:       factory,
+		ControllerNamespace: controllerNamespace,
 	}
 }
 
 type infraCluster struct {
 	k8sclient.Client
-	NoCachedClient k8sclient.Client
-	ClientFactory  ClientFactoryFunc
+	NoCachedClient      k8sclient.Client
+	ClientFactory       ClientFactoryFunc
+	ControllerNamespace string
 }
 
 // GenerateInfraClusterClient creates a client for infra cluster.
@@ -45,11 +47,17 @@ func (w *infraCluster) GenerateInfraClusterClient(infraClusterSecretRef *corev1.
 		return w.NoCachedClient, ownerNamespace, nil
 	}
 
-	infraKubeconfigSecret := &corev1.Secret{}
 	secretNamespace := infraClusterSecretRef.Namespace
 	if secretNamespace == "" {
 		secretNamespace = ownerNamespace
+	} else if secretNamespace != ownerNamespace &&
+		(w.ControllerNamespace == "" || secretNamespace != w.ControllerNamespace) {
+		return nil, "", errors.Errorf(
+			"infraClusterSecretRef.namespace must match the owning resource namespace (%s) or the controller namespace; got %s",
+			ownerNamespace, secretNamespace)
 	}
+
+	infraKubeconfigSecret := &corev1.Secret{}
 	infraKubeconfigSecretKey := k8sclient.ObjectKey{Namespace: secretNamespace, Name: infraClusterSecretRef.Name}
 	if err := w.Get(context, infraKubeconfigSecretKey, infraKubeconfigSecret); err != nil {
 		return nil, "", errors.Wrapf(err, "failed to fetch infra kubeconfig secret %s/%s", infraClusterSecretRef.Namespace, infraClusterSecretRef.Name)

--- a/pkg/infracluster/infracluster_test.go
+++ b/pkg/infracluster/infracluster_test.go
@@ -44,11 +44,90 @@ var _ = Describe("InfraCluster", func() {
 	It("should return the management client and namespace when the infrastructure secret reference is nil", func() {
 		fakeClient = fake.NewClientBuilder().WithScheme(testing.SetupScheme()).Build()
 
-		infraCluster := New(fakeClient, fakeClient)
+		infraCluster := New(fakeClient, fakeClient, "")
 		infraClient, infraNamespace, err := infraCluster.GenerateInfraClusterClient(nil, ownerNamespace, nil)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(infraClient).To(BeIdenticalTo(fakeClient))
 		Expect(infraNamespace).To(Equal(ownerNamespace))
+	})
+
+	It("should reject a cross-namespace infraClusterSecretRef", func() {
+		fakeClient := fake.NewClientBuilder().WithScheme(testing.SetupScheme()).Build()
+
+		infraClusterSecretRef := &corev1.ObjectReference{
+			APIVersion: "v1",
+			Kind:       "Secret",
+			Name:       infraSecretName,
+			Namespace:  "other-namespace",
+		}
+		infraCluster := New(fakeClient, nil, "controller-ns")
+
+		_, _, err := infraCluster.GenerateInfraClusterClient(infraClusterSecretRef, ownerNamespace, nil)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("infraClusterSecretRef.namespace must match"))
+		Expect(err.Error()).To(ContainSubstring(ownerNamespace))
+		Expect(err.Error()).To(ContainSubstring("other-namespace"))
+	})
+
+	It("should allow infraClusterSecretRef pointing to the controller namespace", func() {
+		controllerNS := "capk-system"
+		infraClusterSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      infraSecretName,
+				Namespace: controllerNS,
+			},
+			Data: map[string][]byte{
+				"kubeconfig": []byte(kubeconfig),
+			},
+		}
+		fakeClient = fake.NewClientBuilder().WithScheme(testing.SetupScheme()).WithObjects(infraClusterSecret).Build()
+
+		infraClusterSecretRef := &corev1.ObjectReference{
+			APIVersion: "v1",
+			Kind:       "Secret",
+			Name:       infraSecretName,
+			Namespace:  controllerNS,
+		}
+
+		fakeInfraClient := fake.NewClientBuilder().Build()
+		infraCluster := NewWithFactory(fakeClient, nil,
+			func(config *rest.Config, options client.Options) (client.Client, error) {
+				return fakeInfraClient, nil
+			}, controllerNS,
+		)
+		infraClient, _, err := infraCluster.GenerateInfraClusterClient(infraClusterSecretRef, ownerNamespace, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(infraClient).To(BeIdenticalTo(fakeInfraClient))
+	})
+
+	It("should allow infraClusterSecretRef with same namespace as owner", func() {
+		infraClusterSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      infraSecretName,
+				Namespace: ownerNamespace,
+			},
+			Data: map[string][]byte{
+				"kubeconfig": []byte(kubeconfig),
+			},
+		}
+		fakeClient = fake.NewClientBuilder().WithScheme(testing.SetupScheme()).WithObjects(infraClusterSecret).Build()
+
+		infraClusterSecretRef := &corev1.ObjectReference{
+			APIVersion: "v1",
+			Kind:       "Secret",
+			Name:       infraSecretName,
+			Namespace:  ownerNamespace,
+		}
+
+		fakeInfraClient := fake.NewClientBuilder().Build()
+		infraCluster := NewWithFactory(fakeClient, nil,
+			func(config *rest.Config, options client.Options) (client.Client, error) {
+				return fakeInfraClient, nil
+			}, "",
+		)
+		infraClient, _, err := infraCluster.GenerateInfraClusterClient(infraClusterSecretRef, ownerNamespace, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(infraClient).To(BeIdenticalTo(fakeInfraClient))
 	})
 
 	It("should failed when the referenced infrastructure secret cannot be found", func() {
@@ -59,7 +138,7 @@ var _ = Describe("InfraCluster", func() {
 			Kind:       "Secret",
 			Name:       infraSecretName,
 		}
-		infraCluster := New(fakeClient, nil)
+		infraCluster := New(fakeClient, nil, "")
 
 		_, _, err := infraCluster.GenerateInfraClusterClient(infraClusterSecretRef, ownerNamespace, nil)
 		Expect(errors.IsNotFound(err)).To(BeTrue())
@@ -81,7 +160,7 @@ var _ = Describe("InfraCluster", func() {
 			Name:       infraSecretName,
 		}
 
-		infraCluster := New(fakeClient, nil)
+		infraCluster := New(fakeClient, nil, "")
 		_, _, err := infraCluster.GenerateInfraClusterClient(infraClusterSecretRef, ownerNamespace, nil)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(Equal("failed to retrieve infra kubeconfig from secret: 'kubeconfig' key is missing"))
@@ -105,7 +184,7 @@ var _ = Describe("InfraCluster", func() {
 			Name:       infraSecretName,
 		}
 
-		infraCluster := New(fakeClient, nil)
+		infraCluster := New(fakeClient, nil, "")
 		_, _, err := infraCluster.GenerateInfraClusterClient(infraClusterSecretRef, ownerNamespace, nil)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("failed to create K8s-API client config"))
@@ -135,7 +214,7 @@ var _ = Describe("InfraCluster", func() {
 		infraCluster := NewWithFactory(fakeClient, nil,
 			func(config *rest.Config, options client.Options) (client.Client, error) {
 				return fakeInfraClient, nil
-			},
+			}, "",
 		)
 		infraClient, namespace, err := infraCluster.GenerateInfraClusterClient(infraClusterSecretRef, ownerNamespace, nil)
 		Expect(err).NotTo(HaveOccurred())
@@ -166,7 +245,7 @@ var _ = Describe("InfraCluster", func() {
 		infraCluster := NewWithFactory(fakeClient, nil,
 			func(config *rest.Config, options client.Options) (client.Client, error) {
 				return fakeInfraClient, nil
-			},
+			}, "",
 		)
 		infraClient, namespace, err := infraCluster.GenerateInfraClusterClient(infraClusterSecretRef, ownerNamespace, nil)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/webhookhandler/infrasecretref_validator.go
+++ b/pkg/webhookhandler/infrasecretref_validator.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhookhandler
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
+)
+
+const (
+	kubevirtClusterValidationPath = "/validate-infrastructure-cluster-x-k8s-io-v1alpha1-kubevirtcluster"
+	kubevirtMachineValidationPath = "/validate-infrastructure-cluster-x-k8s-io-v1alpha1-kubevirtmachine"
+)
+
+type infraSecretRefValidator struct {
+	decoder             admission.Decoder
+	controllerNamespace string
+}
+
+func (v *infraSecretRefValidator) HandleCluster(_ context.Context, req admission.Request) admission.Response {
+	cluster := &v1alpha1.KubevirtCluster{}
+
+	switch req.Operation {
+	case admissionv1.Create, admissionv1.Update:
+		if err := v.decoder.Decode(req, cluster); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+		if err := validateInfraClusterSecretRef(cluster.Spec.InfraClusterSecretRef, cluster.Namespace, v.controllerNamespace); err != nil {
+			return admission.Denied(err.Error())
+		}
+	case admissionv1.Delete:
+		// no validation needed on delete
+	default:
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("unknown operation request %q", req.Operation))
+	}
+
+	return admission.Allowed("")
+}
+
+func (v *infraSecretRefValidator) HandleMachine(_ context.Context, req admission.Request) admission.Response {
+	machine := &v1alpha1.KubevirtMachine{}
+
+	switch req.Operation {
+	case admissionv1.Create, admissionv1.Update:
+		if err := v.decoder.Decode(req, machine); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+		if err := validateInfraClusterSecretRef(machine.Spec.InfraClusterSecretRef, machine.Namespace, v.controllerNamespace); err != nil {
+			return admission.Denied(err.Error())
+		}
+	case admissionv1.Delete:
+		// no validation needed on delete
+	default:
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("unknown operation request %q", req.Operation))
+	}
+
+	return admission.Allowed("")
+}
+
+func validateInfraClusterSecretRef(ref *corev1.ObjectReference, resourceNamespace, controllerNamespace string) error {
+	if ref == nil {
+		return nil
+	}
+	if ref.Namespace == "" || ref.Namespace == resourceNamespace {
+		return nil
+	}
+	if controllerNamespace != "" && ref.Namespace == controllerNamespace {
+		return nil
+	}
+	return fmt.Errorf(
+		"spec.infraClusterSecretRef.namespace must be empty, match the resource namespace %q, or reference the controller namespace; got %q",
+		resourceNamespace, ref.Namespace)
+}

--- a/pkg/webhookhandler/infrasecretref_validator_test.go
+++ b/pkg/webhookhandler/infrasecretref_validator_test.go
@@ -1,0 +1,349 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package webhookhandler
+
+import (
+	"context"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"sigs.k8s.io/cluster-api-provider-kubevirt/api/v1alpha1"
+)
+
+var _ = Describe("InfraClusterSecretRef Validation", func() {
+	var (
+		clusterCodec runtime.Codec
+		machineCodec runtime.Codec
+		validator    *infraSecretRefValidator
+		ctx          context.Context
+	)
+
+	BeforeEach(func() {
+		s := scheme.Scheme
+		Expect(v1alpha1.AddToScheme(s)).To(Succeed())
+		codecFactory := serializer.NewCodecFactory(s)
+		clusterCodec = codecFactory.LegacyCodec(v1alpha1.GroupVersion)
+		machineCodec = codecFactory.LegacyCodec(v1alpha1.GroupVersion)
+		validator = &infraSecretRefValidator{decoder: admission.NewDecoder(s), controllerNamespace: "capk-system"}
+		ctx = context.Background()
+	})
+
+	Context("KubevirtCluster validation", func() {
+		It("should allow create with no infraClusterSecretRef", func() {
+			cluster := &v1alpha1.KubevirtCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-ns",
+				},
+			}
+			req := newClusterRequest(admissionv1.Create, cluster, clusterCodec)
+			res := validator.HandleCluster(ctx, req)
+			Expect(res.Allowed).To(BeTrue())
+		})
+
+		It("should allow create with infraClusterSecretRef in same namespace", func() {
+			cluster := &v1alpha1.KubevirtCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-ns",
+				},
+				Spec: v1alpha1.KubevirtClusterSpec{
+					InfraClusterSecretRef: &corev1.ObjectReference{
+						Name:      "my-secret",
+						Namespace: "test-ns",
+					},
+				},
+			}
+			req := newClusterRequest(admissionv1.Create, cluster, clusterCodec)
+			res := validator.HandleCluster(ctx, req)
+			Expect(res.Allowed).To(BeTrue())
+		})
+
+		It("should allow create with infraClusterSecretRef with empty namespace", func() {
+			cluster := &v1alpha1.KubevirtCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-ns",
+				},
+				Spec: v1alpha1.KubevirtClusterSpec{
+					InfraClusterSecretRef: &corev1.ObjectReference{
+						Name: "my-secret",
+					},
+				},
+			}
+			req := newClusterRequest(admissionv1.Create, cluster, clusterCodec)
+			res := validator.HandleCluster(ctx, req)
+			Expect(res.Allowed).To(BeTrue())
+		})
+
+		It("should reject create with infraClusterSecretRef in different namespace", func() {
+			cluster := &v1alpha1.KubevirtCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-ns",
+				},
+				Spec: v1alpha1.KubevirtClusterSpec{
+					InfraClusterSecretRef: &corev1.ObjectReference{
+						Name:      "some-secret",
+						Namespace: "different-ns",
+					},
+				},
+			}
+			req := newClusterRequest(admissionv1.Create, cluster, clusterCodec)
+			res := validator.HandleCluster(ctx, req)
+			Expect(res.Allowed).To(BeFalse())
+			Expect(res.Result.Code).To(Equal(int32(http.StatusForbidden)))
+			Expect(res.Result.Message).To(ContainSubstring("different-ns"))
+			Expect(res.Result.Message).To(ContainSubstring("test-ns"))
+		})
+
+		It("should reject update with infraClusterSecretRef in different namespace", func() {
+			cluster := &v1alpha1.KubevirtCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-ns",
+				},
+				Spec: v1alpha1.KubevirtClusterSpec{
+					InfraClusterSecretRef: &corev1.ObjectReference{
+						Name:      "some-secret",
+						Namespace: "another-ns",
+					},
+				},
+			}
+			req := newClusterRequest(admissionv1.Update, cluster, clusterCodec)
+			res := validator.HandleCluster(ctx, req)
+			Expect(res.Allowed).To(BeFalse())
+			Expect(res.Result.Message).To(ContainSubstring("another-ns"))
+		})
+
+		It("should allow create with infraClusterSecretRef in controller namespace", func() {
+			cluster := &v1alpha1.KubevirtCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-ns",
+				},
+				Spec: v1alpha1.KubevirtClusterSpec{
+					InfraClusterSecretRef: &corev1.ObjectReference{
+						Name:      "infra-kubeconfig",
+						Namespace: "capk-system",
+					},
+				},
+			}
+			req := newClusterRequest(admissionv1.Create, cluster, clusterCodec)
+			res := validator.HandleCluster(ctx, req)
+			Expect(res.Allowed).To(BeTrue())
+		})
+
+		It("should allow delete without validation", func() {
+			cluster := &v1alpha1.KubevirtCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cluster",
+					Namespace: "test-ns",
+				},
+				Spec: v1alpha1.KubevirtClusterSpec{
+					InfraClusterSecretRef: &corev1.ObjectReference{
+						Name:      "some-secret",
+						Namespace: "other-ns",
+					},
+				},
+			}
+			req := newClusterDeleteRequest(cluster, clusterCodec)
+			res := validator.HandleCluster(ctx, req)
+			Expect(res.Allowed).To(BeTrue())
+		})
+	})
+
+	Context("KubevirtMachine validation", func() {
+		It("should allow create with no infraClusterSecretRef", func() {
+			machine := &v1alpha1.KubevirtMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-machine",
+					Namespace: "test-ns",
+				},
+			}
+			req := newMachineRequest(admissionv1.Create, machine, machineCodec)
+			res := validator.HandleMachine(ctx, req)
+			Expect(res.Allowed).To(BeTrue())
+		})
+
+		It("should allow create with infraClusterSecretRef in same namespace", func() {
+			machine := &v1alpha1.KubevirtMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-machine",
+					Namespace: "test-ns",
+				},
+				Spec: v1alpha1.KubevirtMachineSpec{
+					InfraClusterSecretRef: &corev1.ObjectReference{
+						Name:      "my-secret",
+						Namespace: "test-ns",
+					},
+				},
+			}
+			req := newMachineRequest(admissionv1.Create, machine, machineCodec)
+			res := validator.HandleMachine(ctx, req)
+			Expect(res.Allowed).To(BeTrue())
+		})
+
+		It("should reject create with infraClusterSecretRef in different namespace", func() {
+			machine := &v1alpha1.KubevirtMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-machine",
+					Namespace: "test-ns",
+				},
+				Spec: v1alpha1.KubevirtMachineSpec{
+					InfraClusterSecretRef: &corev1.ObjectReference{
+						Name:      "some-secret",
+						Namespace: "different-ns",
+					},
+				},
+			}
+			req := newMachineRequest(admissionv1.Create, machine, machineCodec)
+			res := validator.HandleMachine(ctx, req)
+			Expect(res.Allowed).To(BeFalse())
+			Expect(res.Result.Code).To(Equal(int32(http.StatusForbidden)))
+			Expect(res.Result.Message).To(ContainSubstring("different-ns"))
+		})
+
+		It("should reject update with infraClusterSecretRef in different namespace", func() {
+			machine := &v1alpha1.KubevirtMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-machine",
+					Namespace: "test-ns",
+				},
+				Spec: v1alpha1.KubevirtMachineSpec{
+					InfraClusterSecretRef: &corev1.ObjectReference{
+						Name:      "some-secret",
+						Namespace: "another-ns",
+					},
+				},
+			}
+			req := newMachineRequest(admissionv1.Update, machine, machineCodec)
+			res := validator.HandleMachine(ctx, req)
+			Expect(res.Allowed).To(BeFalse())
+			Expect(res.Result.Message).To(ContainSubstring("another-ns"))
+		})
+	})
+
+	Context("validateInfraClusterSecretRef", func() {
+		It("should return nil for nil ref", func() {
+			Expect(validateInfraClusterSecretRef(nil, "any-ns", "ctrl-ns")).To(Succeed())
+		})
+
+		It("should return nil for empty namespace", func() {
+			ref := &corev1.ObjectReference{Name: "secret"}
+			Expect(validateInfraClusterSecretRef(ref, "any-ns", "ctrl-ns")).To(Succeed())
+		})
+
+		It("should return nil for matching namespace", func() {
+			ref := &corev1.ObjectReference{Name: "secret", Namespace: "my-ns"}
+			Expect(validateInfraClusterSecretRef(ref, "my-ns", "ctrl-ns")).To(Succeed())
+		})
+
+		It("should return nil for controller namespace", func() {
+			ref := &corev1.ObjectReference{Name: "secret", Namespace: "ctrl-ns"}
+			Expect(validateInfraClusterSecretRef(ref, "my-ns", "ctrl-ns")).To(Succeed())
+		})
+
+		It("should return error for unrelated namespace", func() {
+			ref := &corev1.ObjectReference{Name: "secret", Namespace: "other-ns"}
+			err := validateInfraClusterSecretRef(ref, "my-ns", "ctrl-ns")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("other-ns"))
+			Expect(err.Error()).To(ContainSubstring("my-ns"))
+		})
+
+		It("should return error when controller namespace is empty and ref is cross-namespace", func() {
+			ref := &corev1.ObjectReference{Name: "secret", Namespace: "other-ns"}
+			err := validateInfraClusterSecretRef(ref, "my-ns", "")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("other-ns"))
+		})
+	})
+})
+
+func newClusterRequest(operation admissionv1.Operation, obj *v1alpha1.KubevirtCluster, encoder runtime.Encoder) admission.Request {
+	raw := runtime.RawExtension{
+		Raw:    []byte(runtime.EncodeOrDie(encoder, obj)),
+		Object: obj,
+	}
+
+	req := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: operation,
+			Resource: metav1.GroupVersionResource{
+				Group:    v1alpha1.GroupVersion.Group,
+				Version:  v1alpha1.GroupVersion.Version,
+				Resource: "kubevirtclusters",
+			},
+			Namespace: obj.Namespace,
+			UID:       "test-uid",
+			Object:    raw,
+		},
+	}
+
+	return req
+}
+
+func newClusterDeleteRequest(obj *v1alpha1.KubevirtCluster, encoder runtime.Encoder) admission.Request {
+	return admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: admissionv1.Delete,
+			Resource: metav1.GroupVersionResource{
+				Group:    v1alpha1.GroupVersion.Group,
+				Version:  v1alpha1.GroupVersion.Version,
+				Resource: "kubevirtclusters",
+			},
+			Namespace: obj.Namespace,
+			UID:       "test-uid",
+			OldObject: runtime.RawExtension{
+				Raw:    []byte(runtime.EncodeOrDie(encoder, obj)),
+				Object: obj,
+			},
+		},
+	}
+}
+
+func newMachineRequest(operation admissionv1.Operation, obj *v1alpha1.KubevirtMachine, encoder runtime.Encoder) admission.Request {
+	raw := runtime.RawExtension{
+		Raw:    []byte(runtime.EncodeOrDie(encoder, obj)),
+		Object: obj,
+	}
+
+	req := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: operation,
+			Resource: metav1.GroupVersionResource{
+				Group:    v1alpha1.GroupVersion.Group,
+				Version:  v1alpha1.GroupVersion.Version,
+				Resource: "kubevirtmachines",
+			},
+			Namespace: obj.Namespace,
+			UID:       "test-uid",
+			Object:    raw,
+		},
+	}
+
+	return req
+}

--- a/pkg/webhookhandler/validator.go
+++ b/pkg/webhookhandler/validator.go
@@ -36,16 +36,23 @@ const (
 	immutableWarning      = "KubevirtMachineTemplateSpec is immutable"
 )
 
-func SetupWebhookWithManager(mgr ctrl.Manager) error {
+func SetupWebhookWithManager(mgr ctrl.Manager, controllerNamespace string) error {
 	decoder := admission.NewDecoder(mgr.GetScheme())
 
 	whHandler := &kubevirtMachineTemplateHandler{
 		decoder: decoder,
 	}
 
+	infraRefValidator := &infraSecretRefValidator{
+		decoder:             decoder,
+		controllerNamespace: controllerNamespace,
+	}
+
 	srv := mgr.GetWebhookServer()
 
 	srv.Register(webhookValidationPath, &webhook.Admission{Handler: whHandler})
+	srv.Register(kubevirtClusterValidationPath, &webhook.Admission{Handler: admission.HandlerFunc(infraRefValidator.HandleCluster)})
+	srv.Register(kubevirtMachineValidationPath, &webhook.Admission{Handler: admission.HandlerFunc(infraRefValidator.HandleMachine)})
 
 	return nil
 }


### PR DESCRIPTION
Ensure that `infraClusterSecretRef` always resolves within the owning resource's namespace. Previously, a non-empty `.namespace` field was honored verbatim, which could lead to unintended behavior when the field referenced a different namespace.

Changes:
- Add runtime validation in `GenerateInfraClusterClient` that rejects references pointing outside the owner namespace.
- Register validating webhooks for `KubevirtCluster` and `KubevirtMachine` that reject cross-namespace `infraClusterSecretRef` on create/update.
- Reduce RBAC verbs on secrets (drop `delete`, `patch`) and services (drop patch) to match actual controller usage.
- Regenerate CRD and webhook manifests.


<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release notes**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Enforce same-namespace constraint on infraClusterSecretRef and tighten RBAC
```
